### PR TITLE
fix: open the chat pane in the focused workspace's room

### DIFF
--- a/scripts/open-chat-tab.sh
+++ b/scripts/open-chat-tab.sh
@@ -4,9 +4,15 @@ set -euo pipefail
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 herdr_bin="${HERDR_BIN_PATH:-herdr}"
 bash "$script_dir/daemon-ctl.sh" start >/dev/null
+
+# herdr runs plugin actions from the plugin's own directory, so $PWD would pin
+# the pane to this repo's group. The room the human wants is the one their
+# focused workspace resolves to.
+cwd="$("$script_dir/../target/release/scuttlebutt" session-cwd 2>/dev/null || true)"
+[ -n "$cwd" ] && [ -d "$cwd" ] || cwd="$PWD"
 exec "$herdr_bin" plugin pane open \
   --plugin andybarilla.scuttlebutt \
   --entrypoint chat \
   --placement tab \
   --focus \
-  --cwd "$PWD"
+  --cwd "$cwd"

--- a/scripts/open-chat.sh
+++ b/scripts/open-chat.sh
@@ -4,10 +4,16 @@ set -euo pipefail
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 herdr_bin="${HERDR_BIN_PATH:-herdr}"
 bash "$script_dir/daemon-ctl.sh" start >/dev/null
+
+# herdr runs plugin actions from the plugin's own directory, so $PWD would pin
+# the pane to this repo's group. The room the human wants is the one their
+# focused workspace resolves to.
+cwd="$("$script_dir/../target/release/scuttlebutt" session-cwd 2>/dev/null || true)"
+[ -n "$cwd" ] && [ -d "$cwd" ] || cwd="$PWD"
 exec "$herdr_bin" plugin pane open \
   --plugin andybarilla.scuttlebutt \
   --entrypoint chat \
   --placement split \
   --direction right \
   --focus \
-  --cwd "$PWD"
+  --cwd "$cwd"

--- a/src/herd.rs
+++ b/src/herd.rs
@@ -31,6 +31,35 @@ pub fn parse_agent_list(json: &str) -> Result<Vec<AgentInfo>> {
         .collect())
 }
 
+/// The checkout path of the focused workspace, from `herdr workspace list`.
+/// Plugin actions run from the plugin's own directory, so this — not `$PWD` —
+/// is where the human actually is when they open the chat pane.
+pub fn parse_focused_cwd(json: &str) -> Result<String> {
+    let v: serde_json::Value = serde_json::from_str(json).context("parsing workspace list JSON")?;
+    let workspaces = v["result"]["workspaces"]
+        .as_array()
+        .context("missing .result.workspaces")?;
+    workspaces
+        .iter()
+        .find(|w| w["focused"].as_bool().unwrap_or(false))
+        .and_then(|w| w["worktree"]["checkout_path"].as_str())
+        .map(str::to_string)
+        .context("no focused workspace with a checkout path")
+}
+
+pub fn focused_cwd() -> Result<String> {
+    let out = std::process::Command::new("herdr")
+        .args(["workspace", "list"])
+        .output()
+        .context("running `herdr workspace list`")?;
+    anyhow::ensure!(
+        out.status.success(),
+        "herdr workspace list failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    parse_focused_cwd(&String::from_utf8(out.stdout)?)
+}
+
 pub struct RealHerd;
 
 impl HerdControl for RealHerd {
@@ -97,5 +126,35 @@ mod tests {
     fn missing_cwd_is_empty_not_an_error() {
         let agents = parse_agent_list(FIXTURE).unwrap();
         assert_eq!(agents[1].cwd, "");
+    }
+
+    const WORKSPACES: &str = r#"{"id":"cli:workspace:list","result":{"type":"workspace_list","workspaces":[
+        {"focused":false,"workspace_id":"w2C","worktree":{"checkout_path":"/home/andy/dev/alare-leadership/alare"}},
+        {"focused":true,"workspace_id":"w38","worktree":{"checkout_path":"/home/andy/dev/printersrow/kern-app"}}
+    ]}}"#;
+
+    #[test]
+    fn parses_the_focused_workspace_cwd() {
+        assert_eq!(
+            parse_focused_cwd(WORKSPACES).unwrap(),
+            "/home/andy/dev/printersrow/kern-app"
+        );
+    }
+
+    #[test]
+    fn no_focused_workspace_is_an_error_not_a_silent_first_entry() {
+        let json = WORKSPACES.replace("\"focused\":true", "\"focused\":false");
+        assert!(parse_focused_cwd(&json).is_err());
+    }
+
+    #[test]
+    fn focused_workspace_without_a_worktree_is_an_error() {
+        let json = r#"{"result":{"workspaces":[{"focused":true,"workspace_id":"w1"}]}}"#;
+        assert!(parse_focused_cwd(json).is_err());
+    }
+
+    #[test]
+    fn rejects_malformed_workspace_json() {
+        assert!(parse_focused_cwd("not json").is_err());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,6 +61,9 @@ enum Cmd {
     DaemonStatus,
     /// Stop the daemon
     DaemonStop,
+    /// Print the focused workspace's checkout path (used by the pane scripts)
+    #[command(hide = true)]
+    SessionCwd,
     /// Open the chat TUI
     Tui {
         /// Target this group instead of resolving from the calling cwd
@@ -99,6 +102,10 @@ fn main() -> anyhow::Result<()> {
             Ok(())
         }
         Cmd::DaemonStop => daemon::stop(&paths::session_dir()?),
+        Cmd::SessionCwd => {
+            println!("{}", herd::focused_cwd()?);
+            Ok(())
+        }
         Cmd::Tui { group } => tui::run(group.as_deref()),
     }
 }


### PR DESCRIPTION
herdr runs plugin actions from the plugin's own directory, so the pane scripts' `--cwd "$PWD"` pinned every chat pane to this repo's own group instead of the room the human was looking at.