### PR TITLE
feat: install from prebuilt release binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,11 @@ jobs:
         with:
           path: dist
           merge-multiple: true
+      - name: Checksums
+        run: cd dist && sha256sum *.tar.gz > SHA256SUMS
       - uses: softprops/action-gh-release@v2
         with:
-          files: dist/*.tar.gz
+          files: |
+            dist/*.tar.gz
+            dist/SHA256SUMS
           generate_release_notes: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,7 +678,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scuttlebutt"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scuttlebutt"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [dependencies]

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,13 +1,16 @@
 # herdr-plugin.toml
 id = "andybarilla.scuttlebutt"
 name = "Scuttlebutt"
-version = "0.1.0"
+version = "0.1.1"
 min_herdr_version = "0.7.0"
 description = "Shared chat room for the agents in a herdr session"
 platforms = ["linux", "macos"]
 
+# Fetch the prebuilt binary for this version + platform from the GitHub release
+# (no Rust toolchain needed); falls back to cargo build. `herdr plugin link` skips
+# [[build]] entirely — build a local checkout with `cargo build --release`.
 [[build]]
-command = ["cargo", "build", "--release"]
+command = ["/bin/sh", "scripts/fetch-or-build.sh"]
 platforms = ["linux", "macos"]
 
 [[panes]]

--- a/scripts/fetch-or-build.sh
+++ b/scripts/fetch-or-build.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+# scripts/fetch-or-build.sh — herdr [[build]] step, run with cwd = plugin root.
+# Downloads the prebuilt binary for this version + platform from the matching
+# GitHub release and verifies its SHA-256, so installing needs no Rust toolchain.
+# Anything that misses (unmapped platform, no release for this version, download
+# or checksum failure) falls back to `cargo build --release`.
+set -u
+
+repo="andybarilla/herdr-scuttlebutt"
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+repo_root="$script_dir/.."
+out="$repo_root/target/release/scuttlebutt"
+base_url="${SCUTTLEBUTT_BASE_URL:-https://github.com/$repo/releases/download}"
+
+have() { command -v "$1" >/dev/null 2>&1; }
+
+build_from_source() {
+  # herdr may have been launched without ~/.cargo/bin on PATH (GUI or login-less
+  # start), so pick cargo up from its env file when there is one.
+  [ -f "$HOME/.cargo/env" ] && . "$HOME/.cargo/env"
+  have cargo || {
+    echo "scuttlebutt: cargo not found. Install Rust from https://rustup.rs, or re-run once a release exists for this version." >&2
+    exit 1
+  }
+  cd "$repo_root" || exit 1
+  exec cargo build --release
+}
+
+fallback() {
+  echo "scuttlebutt: $1 — building from source instead." >&2
+  rm -rf "${tmpdir:-}"
+  build_from_source
+}
+
+download() {
+  if have curl; then curl -fsSL --retry 2 -o "$2" "$1"
+  elif have wget; then wget -q -O "$2" "$1"
+  else return 127
+  fi
+}
+
+sha256_of() {
+  if have sha256sum; then sha256sum "$1" | awk '{print $1}'
+  elif have shasum; then shasum -a 256 "$1" | awk '{print $1}'
+  else return 127
+  fi
+}
+
+case "$(uname -s 2>/dev/null)/$(uname -m 2>/dev/null)" in
+  Darwin/arm64 | Darwin/aarch64) triple="aarch64-apple-darwin" ;;
+  Darwin/x86_64 | Darwin/amd64)  triple="x86_64-apple-darwin" ;;
+  Linux/aarch64 | Linux/arm64)   triple="aarch64-unknown-linux-gnu" ;;
+  Linux/x86_64 | Linux/amd64)    triple="x86_64-unknown-linux-gnu" ;;
+  *) fallback "no prebuilt binary for $(uname -s)/$(uname -m)" ;;
+esac
+
+version=$(sed -n '/^\[package\]/,/^\[/{s/^version = "\(.*\)"/\1/p;}' "$repo_root/Cargo.toml" | head -n 1)
+[ -n "$version" ] || fallback "could not read the version from Cargo.toml"
+
+asset="scuttlebutt-$version-$triple.tar.gz"
+tmpdir=$(mktemp -d) || fallback "could not create a temp dir"
+trap 'rm -rf "$tmpdir"' EXIT
+
+download "$base_url/v$version/$asset" "$tmpdir/$asset" || fallback "no prebuilt binary published for v$version ($asset)"
+download "$base_url/v$version/SHA256SUMS" "$tmpdir/SHA256SUMS" || fallback "no checksums published for v$version"
+
+# sha256sum's binary mode writes ` *name` where text mode writes `  name`; accept either.
+expected=$(sed -n "s/^\([0-9a-f]\{64\}\) [ *]$asset\$/\1/p" "$tmpdir/SHA256SUMS" | head -n 1)
+[ -n "$expected" ] || fallback "no checksum listed for $asset"
+actual=$(sha256_of "$tmpdir/$asset") || fallback "no sha-256 tool (sha256sum/shasum) available"
+[ "$actual" = "$expected" ] || fallback "checksum mismatch for $asset (expected $expected, got $actual)"
+
+tar -xzf "$tmpdir/$asset" -C "$tmpdir" scuttlebutt || fallback "could not unpack $asset"
+mkdir -p "$(dirname "$out")"
+install -m 755 "$tmpdir/scuttlebutt" "$out" || fallback "could not install the binary to $out"
+echo "scuttlebutt: installed prebuilt v$version ($triple), verified SHA-256."


### PR DESCRIPTION
`herdr plugin install` spawns `[[build]]` directly (no shell), so `cargo build --release` fails with ENOENT on any machine where cargo isn't on the PATH herdr inherited — which is what every other Rust herdr plugin avoids by downloading a release asset.

- `scripts/fetch-or-build.sh`: download `scuttlebutt-$version-$triple.tar.gz` for this version + platform, verify SHA-256, install to `target/release/scuttlebutt`. Any miss (unmapped platform, no release, download/checksum failure) falls back to `cargo build --release`, sourcing `~/.cargo/env` first.
- `release.yml` now publishes `SHA256SUMS` alongside the tarballs.
- Version bumped to 0.1.1 (Cargo.toml, Cargo.lock, herdr-plugin.toml — `version-guard` requires them to match) so a release with checksums exists for the fast path.

Tested against a local `file://` release: happy path, missing release, and checksum mismatch each behave as intended.

Push `v0.1.1` after merge — the fast path needs that release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)