### PR TITLE
fix: launch the chat pane from the plugin root

### DIFF
--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -17,7 +17,7 @@ platforms = ["linux", "macos"]
 id = "chat"
 title = "Scuttlebutt"
 placement = "split"
-command = ["./target/release/scuttlebutt", "tui"]
+command = ["bash", "scripts/pane-chat.sh"]
 
 [[actions]]
 id = "open-chat"

--- a/scripts/open-chat-tab.sh
+++ b/scripts/open-chat-tab.sh
@@ -5,9 +5,10 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 herdr_bin="${HERDR_BIN_PATH:-herdr}"
 bash "$script_dir/daemon-ctl.sh" start >/dev/null
 
-# herdr runs plugin actions from the plugin's own directory, so $PWD would pin
-# the pane to this repo's group. The room the human wants is the one their
-# focused workspace resolves to.
+# herdr resolves the pane's relative command against --cwd, so the pane has to
+# launch from the plugin root. The room the human wants is the one their focused
+# workspace resolves to; that travels separately, in $SCUTTLEBUTT_CWD, and
+# pane-chat.sh cd's there before starting the TUI.
 cwd="$("$script_dir/../target/release/scuttlebutt" session-cwd 2>/dev/null || true)"
 [ -n "$cwd" ] && [ -d "$cwd" ] || cwd="$PWD"
 exec "$herdr_bin" plugin pane open \
@@ -15,4 +16,5 @@ exec "$herdr_bin" plugin pane open \
   --entrypoint chat \
   --placement tab \
   --focus \
-  --cwd "$cwd"
+  --cwd "$script_dir/.." \
+  --env "SCUTTLEBUTT_CWD=$cwd"

--- a/scripts/open-chat.sh
+++ b/scripts/open-chat.sh
@@ -5,9 +5,10 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 herdr_bin="${HERDR_BIN_PATH:-herdr}"
 bash "$script_dir/daemon-ctl.sh" start >/dev/null
 
-# herdr runs plugin actions from the plugin's own directory, so $PWD would pin
-# the pane to this repo's group. The room the human wants is the one their
-# focused workspace resolves to.
+# herdr resolves the pane's relative command against --cwd, so the pane has to
+# launch from the plugin root. The room the human wants is the one their focused
+# workspace resolves to; that travels separately, in $SCUTTLEBUTT_CWD, and
+# pane-chat.sh cd's there before starting the TUI.
 cwd="$("$script_dir/../target/release/scuttlebutt" session-cwd 2>/dev/null || true)"
 [ -n "$cwd" ] && [ -d "$cwd" ] || cwd="$PWD"
 exec "$herdr_bin" plugin pane open \
@@ -16,4 +17,5 @@ exec "$herdr_bin" plugin pane open \
   --placement split \
   --direction right \
   --focus \
-  --cwd "$cwd"
+  --cwd "$script_dir/.." \
+  --env "SCUTTLEBUTT_CWD=$cwd"

--- a/scripts/pane-chat.sh
+++ b/scripts/pane-chat.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# scripts/pane-chat.sh — the chat pane's entrypoint.
+# herdr resolves a pane's relative command against the pane cwd, so the pane
+# must launch from the plugin root. The room the human wants is the one their
+# focused workspace resolves to, which arrives as $SCUTTLEBUTT_CWD; the TUI
+# resolves its group from its own cwd, so switch there before exec'ing.
+set -euo pipefail
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+bin="$script_dir/../target/release/scuttlebutt"
+cwd="${SCUTTLEBUTT_CWD:-}"
+[ -n "$cwd" ] && [ -d "$cwd" ] && cd "$cwd"
+exec "$bin" tui


### PR DESCRIPTION
`herdr plugin action invoke open-chat` failed with:

```
plugin_pane_open_failed: Unable to spawn /home/andy/dev/alare-leadership/alare/./target/release/scuttlebutt because it does not exist
```

herdr resolves a pane's relative command against the pane's `--cwd`. 9284dd4 set `--cwd` to the focused workspace so the TUI would resolve the right group, which made the manifest's `./target/release/scuttlebutt` unresolvable everywhere except the plugin's own checkout — where it was developed and tested.

The pane now launches from the plugin root and the room's directory travels separately in `$SCUTTLEBUTT_CWD`. `scripts/pane-chat.sh` cd's there before exec'ing the TUI, so `tui.rs`'s `current_dir()` group resolution is unchanged. No Rust change, so this needs no version bump or new release to be correct for GitHub installs.

## Verification

Local checkout's scripts + manifest copied over the installed plugin, then:

- `herdr plugin action invoke open-chat` → `exit_code: 0`, pane opened
- pane's `scuttlebutt tui` process cwd = the focused workspace, not the plugin dir
- opening with `--cwd <plugin root> --env SCUTTLEBUTT_CWD=/home/andy/dev/alare-leadership/alare` (the reported failing case) → binary resolves, TUI cwd = alare
- `cargo test`: 151 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)