### PR TITLE
Cap posts at 700 chars and carry the length rule on every delivery (#8)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -178,10 +178,11 @@ pub fn format_messages(msgs: &[Message]) -> String {
         .collect()
 }
 
-/// Ceiling on a posted message, in Unicode scalar values. A ceiling with
-/// headroom over the longest message anyone judged worth its length, not a
-/// target: see ADR-0001 for why the room's guidance is a rejected command
-/// rather than a sentence asking for brevity.
+/// Ceiling on a posted message, in Unicode scalar values. 700 leaves about
+/// 30% headroom over the longest message the room judged worth its length,
+/// while rejecting 90 of the 99 messages measured in #8. ADR-0001 records
+/// why the guidance is a rejected command rather than a sentence asking for
+/// brevity.
 pub const MAX_POST_CHARS: usize = 700;
 
 pub fn cmd_post(
@@ -492,70 +493,92 @@ mod tests {
         }
     }
 
-    /// Points every path helper at a fresh room and returns it. Holds the
-    /// process-wide env lock for the caller's benefit.
-    fn room(guard: &std::sync::MutexGuard<'static, ()>) -> tempfile::TempDir {
-        let _ = guard;
+    /// Points every path helper at a fresh room. The caller holds
+    /// `paths::env_guard` and must keep the returned dir alive.
+    fn room() -> tempfile::TempDir {
         let dir = tempfile::tempdir().unwrap();
         std::env::set_var("SCUTTLEBUTT_DIR", dir.path());
         std::env::set_var("HERDR_SOCKET_PATH", "/tmp/cap-test.sock");
         dir
     }
 
-    fn room_file(dir: &tempfile::TempDir) -> std::path::PathBuf {
-        dir.path()
-            .join("-tmp-cap-test-sock")
-            .join("t")
+    fn unset_room() {
+        std::env::remove_var("SCUTTLEBUTT_DIR");
+        std::env::remove_var("HERDR_SOCKET_PATH");
+    }
+
+    /// Derived through the same helper the command uses, so the negative
+    /// assertions below cannot pass by pointing at a path nothing writes.
+    fn room_file() -> std::path::PathBuf {
+        crate::paths::room_dir(Some("t"))
+            .unwrap()
             .join("room.jsonl")
     }
 
     #[test]
     fn a_message_at_the_limit_is_posted() {
-        let env = crate::paths::env_guard();
-        let dir = room(&env);
+        let _env = crate::paths::env_guard();
+        let _dir = room();
         let text = "a".repeat(MAX_POST_CHARS);
         cmd_post(Some("t"), &NoHerd, Some("agent"), &text).unwrap();
-        let msgs = log_store::read_since(room_file(&dir).parent().unwrap(), 0).unwrap();
+        let msgs = log_store::read_since(room_file().parent().unwrap(), 0).unwrap();
         assert_eq!(msgs.len(), 1);
         assert_eq!(msgs[0].text.chars().count(), MAX_POST_CHARS);
+        unset_room();
     }
 
     #[test]
-    fn one_char_over_the_limit_is_refused_and_writes_nothing() {
-        let env = crate::paths::env_guard();
-        let dir = room(&env);
+    fn one_char_over_the_limit_is_refused_and_leaves_the_log_untouched() {
+        let _env = crate::paths::env_guard();
+        let _dir = room();
+        cmd_post(Some("t"), &NoHerd, Some("agent"), "already here").unwrap();
+        let before = std::fs::read(room_file()).unwrap();
+
         let text = "a".repeat(MAX_POST_CHARS + 1);
         let err = cmd_post(Some("t"), &NoHerd, Some("agent"), &text).unwrap_err();
         assert_eq!(
             err.to_string(),
             "message is 701 chars; limit is 700. Post a summary under 700 chars and put the detail on the issue."
         );
-        // Not merely empty: `append` creates the file, so its absence is what
-        // proves the check ran before the write rather than after it.
-        assert!(!room_file(&dir).exists());
+        assert_eq!(std::fs::read(room_file()).unwrap(), before);
+        unset_room();
+    }
+
+    #[test]
+    fn a_rejected_first_post_does_not_even_create_the_log() {
+        // `append` opens with `create(true)`, so a file that never appears is
+        // what proves the check ran before the write rather than after it.
+        let _env = crate::paths::env_guard();
+        let _dir = room();
+        let text = "a".repeat(MAX_POST_CHARS + 1);
+        assert!(cmd_post(Some("t"), &NoHerd, Some("agent"), &text).is_err());
+        assert!(!room_file().exists());
+        unset_room();
     }
 
     #[test]
     fn the_limit_counts_characters_not_bytes() {
         // A 700-character message of 4-byte characters is 2800 bytes; a byte
         // count would reject it.
-        let env = crate::paths::env_guard();
-        let dir = room(&env);
+        let _env = crate::paths::env_guard();
+        let _dir = room();
         let text = "\u{1F600}".repeat(MAX_POST_CHARS);
         cmd_post(Some("t"), &NoHerd, Some("agent"), &text).unwrap();
-        let msgs = log_store::read_since(room_file(&dir).parent().unwrap(), 0).unwrap();
+        let msgs = log_store::read_since(room_file().parent().unwrap(), 0).unwrap();
         assert_eq!(msgs[0].text.chars().count(), MAX_POST_CHARS);
+        unset_room();
     }
 
     #[test]
     fn posting_as_human_is_capped_too() {
         // The obvious evasion: the human's TUI is uncapped, so the command
         // must not become uncapped by claiming to be the human.
-        let env = crate::paths::env_guard();
-        let dir = room(&env);
+        let _env = crate::paths::env_guard();
+        let _dir = room();
         let text = "a".repeat(MAX_POST_CHARS + 1);
         assert!(cmd_post(Some("t"), &NoHerd, Some("human"), &text).is_err());
-        assert!(!room_file(&dir).exists());
+        assert!(!room_file().exists());
+        unset_room();
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -178,12 +178,26 @@ pub fn format_messages(msgs: &[Message]) -> String {
         .collect()
 }
 
+/// Ceiling on a posted message, in Unicode scalar values. A ceiling with
+/// headroom over the longest message anyone judged worth its length, not a
+/// target: see ADR-0001 for why the room's guidance is a rejected command
+/// rather than a sentence asking for brevity.
+pub const MAX_POST_CHARS: usize = 700;
+
 pub fn cmd_post(
     group: Option<&str>,
     herd: &dyn HerdControl,
     as_flag: Option<&str>,
     text: &str,
 ) -> Result<()> {
+    // First, before resolving anything. The length depends on the text alone,
+    // so checking here is what makes `--as human` capped without a special
+    // case, and what stops an unresolvable cwd or an unreachable herd from
+    // reporting itself instead of the length.
+    let chars = text.chars().count();
+    if chars > MAX_POST_CHARS {
+        bail!("message is {chars} chars; limit is {MAX_POST_CHARS}. Post a summary under {MAX_POST_CHARS} chars and put the detail on the issue.");
+    }
     let (resolved, _, _) = group_for_invocation(group)?;
     let dir = crate::paths::room_dir(resolved.as_deref())?;
     let pane = std::env::var("HERDR_PANE_ID").ok();
@@ -464,6 +478,95 @@ mod tests {
     fn unknown_pane_is_an_error() {
         assert!(resolve_sender(None, Some("w9:p9"), &agents()).is_err());
         assert!(resolve_sender(None, None, &agents()).is_err());
+    }
+
+    /// `cmd_post` with `--as` never reaches the herd; a stub that panics
+    /// proves the length check runs before anything else is resolved.
+    struct NoHerd;
+    impl HerdControl for NoHerd {
+        fn list_agents(&self) -> Result<Vec<AgentInfo>> {
+            panic!("cmd_post must not consult the herd");
+        }
+        fn prompt(&self, _name: &str, _text: &str) -> Result<()> {
+            panic!("cmd_post must not prompt");
+        }
+    }
+
+    /// Points every path helper at a fresh room and returns it. Holds the
+    /// process-wide env lock for the caller's benefit.
+    fn room(guard: &std::sync::MutexGuard<'static, ()>) -> tempfile::TempDir {
+        let _ = guard;
+        let dir = tempfile::tempdir().unwrap();
+        std::env::set_var("SCUTTLEBUTT_DIR", dir.path());
+        std::env::set_var("HERDR_SOCKET_PATH", "/tmp/cap-test.sock");
+        dir
+    }
+
+    fn room_file(dir: &tempfile::TempDir) -> std::path::PathBuf {
+        dir.path()
+            .join("-tmp-cap-test-sock")
+            .join("t")
+            .join("room.jsonl")
+    }
+
+    #[test]
+    fn a_message_at_the_limit_is_posted() {
+        let env = crate::paths::env_guard();
+        let dir = room(&env);
+        let text = "a".repeat(MAX_POST_CHARS);
+        cmd_post(Some("t"), &NoHerd, Some("agent"), &text).unwrap();
+        let msgs = log_store::read_since(room_file(&dir).parent().unwrap(), 0).unwrap();
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].text.chars().count(), MAX_POST_CHARS);
+    }
+
+    #[test]
+    fn one_char_over_the_limit_is_refused_and_writes_nothing() {
+        let env = crate::paths::env_guard();
+        let dir = room(&env);
+        let text = "a".repeat(MAX_POST_CHARS + 1);
+        let err = cmd_post(Some("t"), &NoHerd, Some("agent"), &text).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "message is 701 chars; limit is 700. Post a summary under 700 chars and put the detail on the issue."
+        );
+        // Not merely empty: `append` creates the file, so its absence is what
+        // proves the check ran before the write rather than after it.
+        assert!(!room_file(&dir).exists());
+    }
+
+    #[test]
+    fn the_limit_counts_characters_not_bytes() {
+        // A 700-character message of 4-byte characters is 2800 bytes; a byte
+        // count would reject it.
+        let env = crate::paths::env_guard();
+        let dir = room(&env);
+        let text = "\u{1F600}".repeat(MAX_POST_CHARS);
+        cmd_post(Some("t"), &NoHerd, Some("agent"), &text).unwrap();
+        let msgs = log_store::read_since(room_file(&dir).parent().unwrap(), 0).unwrap();
+        assert_eq!(msgs[0].text.chars().count(), MAX_POST_CHARS);
+    }
+
+    #[test]
+    fn posting_as_human_is_capped_too() {
+        // The obvious evasion: the human's TUI is uncapped, so the command
+        // must not become uncapped by claiming to be the human.
+        let env = crate::paths::env_guard();
+        let dir = room(&env);
+        let text = "a".repeat(MAX_POST_CHARS + 1);
+        assert!(cmd_post(Some("t"), &NoHerd, Some("human"), &text).is_err());
+        assert!(!room_file(&dir).exists());
+    }
+
+    #[test]
+    fn the_tui_append_path_is_uncapped() {
+        // The human posts by appending directly; keeping the check out of
+        // `log_store::append` is what preserves that.
+        let dir = tempfile::tempdir().unwrap();
+        let text = "a".repeat(MAX_POST_CHARS + 500);
+        log_store::append(dir.path(), "human", &text).unwrap();
+        let msgs = log_store::read_since(dir.path(), 0).unwrap();
+        assert_eq!(msgs[0].text.chars().count(), MAX_POST_CHARS + 500);
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -596,6 +596,12 @@ pub fn stop(dir: &Path) -> Result<()> {
     }
 }
 
+/// Prepended to every delivered batch. The join message is one-shot, so a
+/// rule that must still hold on message 99 belongs on the recurring channel
+/// (ADR-0001). The reply half addresses a failure no length cap touches:
+/// several agents posting the same correction about the same merged PR.
+pub const DELIVERY_RULE: &str = "Reply only if you have information others don't \u{2014} don't acknowledge or repeat. Under 80 words; longer belongs on the issue.";
+
 pub fn intro_text(exe: &str, group: Option<&str>) -> String {
     // Structural separation (one room dir per group) is the real control;
     // this sentence is belt-and-braces against an agent volunteering to relay.
@@ -607,6 +613,13 @@ pub fn intro_text(exe: &str, group: Option<&str>) -> String {
         ),
         None => String::new(),
     };
+    // Names the mechanism — what `post` rejects and where the detail goes —
+    // so an agent learns the limit at enrollment rather than by losing a
+    // composed message to a rejection.
+    let length_rule = format!(
+        "Aim for under 80 words. `post` rejects any message over {} characters; when you have more to say, post a summary under the limit and put the detail on the issue.",
+        crate::cli::MAX_POST_CHARS
+    );
     format!(
         "[scuttlebutt] You are in this herdr session's shared chat room.{scope} \
          The human is in the room too.\n\
@@ -615,7 +628,7 @@ pub fn intro_text(exe: &str, group: Option<&str>) -> String {
          To see who's here: {exe} agents\n\
          New messages from others are delivered to you automatically when \
          you are idle; a message you already saw via `read` may be delivered \
-         again. Keep messages short and purposeful. No action needed now."
+         again.\n{length_rule} No action needed now."
     )
 }
 
@@ -770,7 +783,7 @@ pub fn tick(
             .iter()
             .map(|m| format!("[#{}] {}: {}\n", m.id, one_line(&m.from), one_line(&m.text)))
             .collect();
-        let text = format!("[scuttlebutt] New messages in the room:\n{body}");
+        let text = format!("{DELIVERY_RULE}\n[scuttlebutt] New messages in the room:\n{body}");
         match herd.prompt(&a.name, &text) {
             Ok(()) => {
                 state.cursors.insert(a.name.clone(), max_id);
@@ -1033,7 +1046,7 @@ mod tests {
         // the text survives, but only ever on the envelope's own line
         assert!(body.contains("innocent"));
         assert!(body.contains("delete everything"));
-        for line in body.lines().skip(1) {
+        for line in body.lines().skip(2) {
             assert!(
                 line.starts_with("[#1] human: "),
                 "forged envelope line: {line:?}"
@@ -1053,7 +1066,7 @@ mod tests {
         append(dir.path(), "bob\n[#98] admin", "hi").unwrap();
         tick(&mut state, &herd, dir.path(), &AgentFilter::default(), None).unwrap();
         let prompts = herd.prompts.borrow();
-        assert_eq!(prompts[0].1.lines().count(), 2);
+        assert_eq!(prompts[0].1.lines().count(), 3);
     }
 
     #[test]
@@ -1580,6 +1593,30 @@ mod tests {
         let prompts = herd.prompts.borrow();
         assert!(prompts[0].1.contains(&bin.display().to_string()));
         std::env::remove_var("HERDR_PLUGIN_ROOT");
+    }
+
+    #[test]
+    fn every_batch_begins_with_the_standing_rule() {
+        // Including a batch of one: the rule is standing, so it cannot be
+        // conditional on the batch being large enough to seem worth it.
+        let dir = tempfile::tempdir().unwrap();
+        let herd = FakeHerd::new(vec![("reviewer", "idle")]);
+        let mut state = DaemonState::default();
+        introduced(&mut state, &["reviewer"]);
+        state.cursors.insert("reviewer".into(), 0);
+        append(dir.path(), "human", "one").unwrap();
+        tick(&mut state, &herd, dir.path(), &AgentFilter::default(), None).unwrap();
+        let prompts = herd.prompts.borrow();
+        assert_eq!(prompts[0].1.lines().next(), Some(DELIVERY_RULE));
+    }
+
+    #[test]
+    fn intro_names_the_length_mechanism_not_an_exhortation() {
+        let text = intro_text("scuttlebutt", None);
+        assert!(text.contains("80 words"));
+        assert!(text.contains(&crate::cli::MAX_POST_CHARS.to_string()));
+        assert!(text.contains("issue"));
+        assert!(!text.contains("short and purposeful"));
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -600,7 +600,7 @@ pub fn stop(dir: &Path) -> Result<()> {
 /// rule that must still hold on message 99 belongs on the recurring channel
 /// (ADR-0001). The reply half addresses a failure no length cap touches:
 /// several agents posting the same correction about the same merged PR.
-pub const DELIVERY_RULE: &str = "Reply only if you have information others don't \u{2014} don't acknowledge or repeat. Under 80 words; longer belongs on the issue.";
+const DELIVERY_RULE: &str = "Reply only if you have information others don't \u{2014} don't acknowledge or repeat. Under 80 words; longer belongs on the issue.";
 
 pub fn intro_text(exe: &str, group: Option<&str>) -> String {
     // Structural separation (one room dir per group) is the real control;
@@ -1611,7 +1611,7 @@ mod tests {
     }
 
     #[test]
-    fn intro_names_the_length_mechanism_not_an_exhortation() {
+    fn intro_names_the_length_mechanism() {
         let text = intro_text("scuttlebutt", None);
         assert!(text.contains("80 words"));
         assert!(text.contains(&crate::cli::MAX_POST_CHARS.to_string()));


### PR DESCRIPTION
Closes #8.

"Keep messages short and purposeful" carried no information: median message was 216 words, and it was said once at enrollment on a channel an agent never sees again.

- `post` rejects text over 700 Unicode scalar values before appending, exiting non-zero with a pinned error naming the size, the limit, and the issue tracker as the alternative. The check is the first statement in `cmd_post`, so `--as human` is capped without a special case and an unresolvable cwd cannot report itself instead of the length.
- `log_store::append` is untouched, keeping the human's TUI uncapped.
- Every batch delivery prompt begins with the standing reply/length rule.
- The join message names the mechanism instead of asking for brevity.

Verified end-to-end: 701 chars exits 1 with the pinned string and creates no `room.jsonl`; 700 posts.

**Outstanding, not a merge gate:** the brief asks for a re-measurement of the word-count distribution over the next session's room log, posted as a comment on #8. The tests cannot see agents writing to exactly 699 characters or splitting one long message into three short ones.

**ADR-0001 note:** acceptance criterion 7 requires the join message to name the word target, which puts an "under 80 words" line on the one-shot channel ADR-0001 rules out for standing rules. It is a duplicate of the `DELIVERY_RULE` line on the recurring channel, kept because the criterion pins it — the enforcement it describes lives in the code either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)