### PR TITLE
Streamline version bumps and check them on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  versions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - run: scripts/check-versions.sh
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,17 +17,9 @@ jobs:
       - uses: actions/checkout@v5
       - id: version
         run: |
-          cargo_version=$(sed -n '/^\[package\]/,/^\[/{s/^version = "\(.*\)"/\1/p}' Cargo.toml)
-          plugin_version=$(sed -n 's/^version = "\(.*\)"/\1/p' herdr-plugin.toml | head -1)
-          if [ "$cargo_version" != "$plugin_version" ]; then
-            echo "Cargo.toml $cargo_version != herdr-plugin.toml $plugin_version" >&2
-            exit 1
-          fi
-          if [ "${GITHUB_REF_TYPE}" = tag ] && [ "${GITHUB_REF_NAME#v}" != "$cargo_version" ]; then
-            echo "tag ${GITHUB_REF_NAME} != version $cargo_version" >&2
-            exit 1
-          fi
-          echo "version=$cargo_version" >> "$GITHUB_OUTPUT"
+          tag=
+          if [ "$GITHUB_REF_TYPE" = tag ]; then tag=$GITHUB_REF_NAME; fi
+          echo "version=$(scripts/check-versions.sh $tag)" >> "$GITHUB_OUTPUT"
 
   build:
     needs: version-guard

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,8 @@ jobs:
         run: |
           tag=
           if [ "$GITHUB_REF_TYPE" = tag ]; then tag=$GITHUB_REF_NAME; fi
-          echo "version=$(scripts/check-versions.sh $tag)" >> "$GITHUB_OUTPUT"
+          version=$(scripts/check-versions.sh $tag)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
 
   build:
     needs: version-guard

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,7 +678,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scuttlebutt"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,7 +1,7 @@
 # herdr-plugin.toml
 id = "andybarilla.scuttlebutt"
 name = "Scuttlebutt"
-version = "0.1.1"
+version = "0.2.0"
 min_herdr_version = "0.7.0"
 description = "Shared chat room for the agents in a herdr session"
 platforms = ["linux", "macos"]

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# scripts/check-versions.sh [vX.Y.Z] — the version lives in Cargo.toml (the source
+# of truth), herdr-plugin.toml, Cargo.lock and the release tag; they must agree.
+# Prints the version. Pass a tag name to check that too.
+set -eu
+
+root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+
+cargo_version=$(sed -n '/^\[package\]/,/^\[/{s/^version = "\(.*\)"/\1/p;}' "$root/Cargo.toml" | head -n 1)
+plugin_version=$(sed -n 's/^version = "\(.*\)"/\1/p' "$root/herdr-plugin.toml" | head -n 1)
+lock_version=$(awk '/^name = "scuttlebutt"$/ {getline; gsub(/^version = "|"$/, ""); print; exit}' "$root/Cargo.lock")
+
+fail() { echo "check-versions: $1" >&2; exit 1; }
+
+[ -n "$cargo_version" ] || fail "no [package] version in Cargo.toml"
+[ "$plugin_version" = "$cargo_version" ] || fail "herdr-plugin.toml $plugin_version != Cargo.toml $cargo_version"
+[ "$lock_version" = "$cargo_version" ] || fail "Cargo.lock $lock_version != Cargo.toml $cargo_version — run scripts/release.sh $cargo_version"
+
+if [ $# -gt 0 ] && [ "${1#v}" != "$cargo_version" ]; then
+  fail "tag $1 != version $cargo_version"
+fi
+
+echo "$cargo_version"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+# scripts/release.sh X.Y.Z — set the version in Cargo.toml, herdr-plugin.toml and
+# Cargo.lock. Commit the result on a branch and merge it; tagging the merged
+# commit is a separate step (pushing the tag is what fires the release).
+set -eu
+
+version=${1:-}
+case "$version" in
+  *.*.*) ;;
+  *) echo "usage: scripts/release.sh X.Y.Z" >&2; exit 1 ;;
+esac
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+root="$script_dir/.."
+cd "$root"
+
+# Anchored to ^version so herdr-plugin.toml's min_herdr_version is left alone.
+sed "/^\[package\]/,/^\[/ s/^version = .*/version = \"$version\"/" Cargo.toml > Cargo.toml.tmp
+mv Cargo.toml.tmp Cargo.toml
+sed "s/^version = .*/version = \"$version\"/" herdr-plugin.toml > herdr-plugin.toml.tmp
+mv herdr-plugin.toml.tmp herdr-plugin.toml
+
+cargo update -p scuttlebutt
+"$script_dir/check-versions.sh" >/dev/null
+
+echo "Bumped to $version. Next: commit, open a PR, and once it is merged:"
+echo "  git tag v$version <merge commit> && git push origin v$version"


### PR DESCRIPTION
`v0.1.2` and `v0.2.0` both failed the release version guard, so neither published binaries; CI on `main` was red against the stale `Cargo.lock`.

- Align `herdr-plugin.toml` and `Cargo.lock` with `Cargo.toml` at 0.2.0.
- `scripts/release.sh X.Y.Z` sets the version in both tomls and refreshes the lock.
- `scripts/check-versions.sh` holds the guard; `ci.yml` now runs it on every PR, and `release.yml` calls it instead of its inline copy.

`v0.2.0` needs re-tagging on the merge commit once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)