### PR TITLE
Release 0.2.1: commit the bump, gate the tag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,7 +678,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scuttlebutt"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scuttlebutt"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [dependencies]

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,7 +1,7 @@
 # herdr-plugin.toml
 id = "andybarilla.scuttlebutt"
 name = "Scuttlebutt"
-version = "0.2.0"
+version = "0.2.1"
 min_herdr_version = "0.7.0"
 description = "Shared chat room for the agents in a herdr session"
 platforms = ["linux", "macos"]

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
-# scripts/release.sh X.Y.Z — set the version in Cargo.toml, herdr-plugin.toml and
-# Cargo.lock. Commit the result on a branch and merge it; tagging the merged
-# commit is a separate step (pushing the tag is what fires the release).
+# scripts/release.sh X.Y.Z — branch, set the version in Cargo.toml,
+# herdr-plugin.toml and Cargo.lock, and commit. Open a PR with that commit; once
+# it is merged, scripts/tag-release.sh publishes the release from main.
 set -eu
 
 version=${1:-}
@@ -11,8 +11,14 @@ case "$version" in
 esac
 
 script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
-root="$script_dir/.."
-cd "$root"
+cd "$script_dir/.."
+
+if [ -n "$(git status --porcelain)" ]; then
+  echo "release: working tree is dirty — commit or stash first" >&2
+  exit 1
+fi
+
+git checkout -q -b "release-$version"
 
 # Anchored to ^version so herdr-plugin.toml's min_herdr_version is left alone.
 sed "/^\[package\]/,/^\[/ s/^version = .*/version = \"$version\"/" Cargo.toml > Cargo.toml.tmp
@@ -22,6 +28,7 @@ mv herdr-plugin.toml.tmp herdr-plugin.toml
 
 cargo update -p scuttlebutt
 "$script_dir/check-versions.sh" >/dev/null
+git commit -qam "chore: release $version"
 
-echo "Bumped to $version. Next: commit, open a PR, and once it is merged:"
-echo "  git tag v$version <merge commit> && git push origin v$version"
+echo "Committed the $version bump on release-$version."
+echo "Open a PR; once it is merged, run scripts/tag-release.sh from an up-to-date main."

--- a/scripts/tag-release.sh
+++ b/scripts/tag-release.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# scripts/tag-release.sh — tag the merged version bump and push it, which is what
+# builds and publishes the release. Everything it checks, the release workflow
+# checks too; failing here costs a second instead of a runner.
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+cd "$script_dir/.."
+
+fail() { echo "tag-release: $1" >&2; exit 1; }
+
+if [ -n "$(git status --porcelain)" ]; then
+  fail "working tree is dirty — the tag would not match what you have here"
+fi
+
+branch=$(git rev-parse --abbrev-ref HEAD)
+[ "$branch" = main ] || fail "on $branch — release from main, after the bump PR is merged"
+
+git fetch -q origin main
+if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]; then
+  fail "main is out of sync with origin/main — pull first"
+fi
+
+version=$("$script_dir/check-versions.sh")
+tag="v$version"
+
+if git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
+  fail "$tag already exists locally"
+fi
+if git ls-remote --exit-code --tags origin "$tag" >/dev/null 2>&1; then
+  fail "$tag already exists on origin"
+fi
+
+git tag "$tag"
+git push origin "$tag"
+echo "Pushed $tag — the release workflow is building it."


### PR DESCRIPTION
`v0.2.1` failed the guard because the bump was still uncommitted — the tag pointed at a tree that still said 0.2.0. `release.sh` printed "next: commit, open a PR" and nothing enforced it.

- `release.sh X.Y.Z` now refuses a dirty tree, creates `release-X.Y.Z`, bumps, and commits.
- `scripts/tag-release.sh` derives the tag from `Cargo.toml`, so it cannot disagree with the tree, and refuses a dirty tree, a non-`main` branch, a `main` out of sync with origin, or a tag that already exists.
- Bumps the version to 0.2.1.

Verified both scripts against a throwaway origin: happy path plus every refusal branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)