### PR TITLE
Refuse a prebuilt binary that is not this checkout's commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
+      sha: ${{ steps.version.outputs.sha }}
     steps:
       - uses: actions/checkout@v5
       - id: version
@@ -21,6 +22,7 @@ jobs:
           if [ "$GITHUB_REF_TYPE" = tag ]; then tag=$GITHUB_REF_NAME; fi
           version=$(scripts/check-versions.sh $tag)
           echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
   build:
     needs: version-guard
@@ -64,18 +66,24 @@ jobs:
 
   release:
     if: github.ref_type == 'tag'
-    needs: build
+    needs: [version-guard, build]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4
         with:
           path: dist
           merge-multiple: true
-      - name: Checksums
-        run: cd dist && sha256sum *.tar.gz > SHA256SUMS
+      - name: Checksums and commit stamp
+        # scripts/fetch-or-build.sh refuses the prebuilt when the checkout it is
+        # building for sits on any other commit than this one.
+        run: |
+          cd dist
+          sha256sum *.tar.gz > SHA256SUMS
+          echo "${{ needs.version-guard.outputs.sha }}" > COMMIT
       - uses: softprops/action-gh-release@v2
         with:
           files: |
             dist/*.tar.gz
             dist/SHA256SUMS
+            dist/COMMIT
           generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -11,8 +11,11 @@ under `~/dev/printersrow`.
 ## Install
 
 ```sh
-herdr plugin install andybarilla/herdr-scuttlebutt
+herdr plugin install andybarilla/herdr-scuttlebutt --ref v0.2.1
 ```
+
+The tag is what has a prebuilt binary; installing from the default branch builds
+from source with `cargo build --release`.
 
 Or, working on it locally:
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ under `~/dev/printersrow`.
 herdr plugin install andybarilla/herdr-scuttlebutt --ref v0.2.1
 ```
 
-The tag is what has a prebuilt binary; installing from the default branch builds
-from source with `cargo build --release`.
+The prebuilt binary is only used when the checkout is the commit that release
+was built from, so installing from the default branch generally builds from
+source with `cargo build --release`.
 
 Or, working on it locally:
 

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 # scripts/check-versions.sh [vX.Y.Z] — the version lives in Cargo.toml (the source
-# of truth), herdr-plugin.toml, Cargo.lock and the release tag; they must agree.
+# of truth), herdr-plugin.toml, Cargo.lock, the README's install command and the
+# release tag; they must agree.
 # Prints the version. Pass a tag name to check that too.
 set -eu
 
@@ -9,12 +10,14 @@ root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 cargo_version=$(sed -n '/^\[package\]/,/^\[/{s/^version = "\(.*\)"/\1/p;}' "$root/Cargo.toml" | head -n 1)
 plugin_version=$(sed -n 's/^version = "\(.*\)"/\1/p' "$root/herdr-plugin.toml" | head -n 1)
 lock_version=$(awk '/^name = "scuttlebutt"$/ {getline; gsub(/^version = "|"$/, ""); print; exit}' "$root/Cargo.lock")
+readme_version=$(sed -n 's|^herdr plugin install andybarilla/herdr-scuttlebutt --ref v\(.*\)$|\1|p' "$root/README.md" | head -n 1)
 
 fail() { echo "check-versions: $1" >&2; exit 1; }
 
 [ -n "$cargo_version" ] || fail "no [package] version in Cargo.toml"
 [ "$plugin_version" = "$cargo_version" ] || fail "herdr-plugin.toml $plugin_version != Cargo.toml $cargo_version"
 [ "$lock_version" = "$cargo_version" ] || fail "Cargo.lock $lock_version != Cargo.toml $cargo_version — run scripts/release.sh $cargo_version"
+[ "$readme_version" = "$cargo_version" ] || fail "README install command ${readme_version:-(no --ref)} != Cargo.toml $cargo_version"
 
 if [ $# -gt 0 ] && [ "${1#v}" != "$cargo_version" ]; then
   fail "tag $1 != version $cargo_version"

--- a/scripts/fetch-or-build.sh
+++ b/scripts/fetch-or-build.sh
@@ -2,8 +2,10 @@
 # scripts/fetch-or-build.sh — herdr [[build]] step, run with cwd = plugin root.
 # Downloads the prebuilt binary for this version + platform from the matching
 # GitHub release and verifies its SHA-256, so installing needs no Rust toolchain.
-# Anything that misses (unmapped platform, no release for this version, download
-# or checksum failure) falls back to `cargo build --release`.
+# The release also stamps the commit it was built from, and a checkout sitting on
+# any other commit gets built from source instead of handed an older binary.
+# Anything that misses (unmapped platform, no release for this version, commit
+# mismatch, download or checksum failure) falls back to `cargo build --release`.
 set -u
 
 repo="andybarilla/herdr-scuttlebutt"
@@ -20,7 +22,7 @@ build_from_source() {
   # start), so pick cargo up from its env file when there is one.
   [ -f "$HOME/.cargo/env" ] && . "$HOME/.cargo/env"
   have cargo || {
-    echo "scuttlebutt: cargo not found. Install Rust from https://rustup.rs, or re-run once a release exists for this version." >&2
+    echo "scuttlebutt: cargo not found. Install Rust from https://rustup.rs, or re-install at a release tag (--ref v${version:-X.Y.Z}) to get a prebuilt binary." >&2
     exit 1
   }
   cd "$repo_root" || exit 1
@@ -61,6 +63,22 @@ version=$(sed -n '/^\[package\]/,/^\[/{s/^version = "\(.*\)"/\1/p;}' "$repo_root
 asset="scuttlebutt-$version-$triple.tar.gz"
 tmpdir=$(mktemp -d) || fallback "could not create a temp dir"
 trap 'rm -rf "$tmpdir"' EXIT
+
+# The prebuilt is only right for the commit it was built from, and Cargo.toml
+# still says the released version until the next bump lands — so a clone of main
+# names a version whose binary is older than its source. herdr clones shallow and
+# without tags, so `git describe` can never answer this; the release stamps its
+# commit in COMMIT and we compare that against HEAD. A missing COMMIT means a
+# release published before stamping, and in that window HEAD is not the tag
+# either, so treating it as a mismatch is the right answer, not a gap to close.
+download "$base_url/v$version/COMMIT" "$tmpdir/COMMIT" || fallback "no prebuilt binary published for v$version (no commit stamp)"
+released=$(tr -d ' \t\r\n' < "$tmpdir/COMMIT")
+# No git metadata means this is not a herdr install (that clones; `plugin link`
+# skips [[build]]), so there is nothing to compare HEAD against.
+head=$(git -C "$repo_root" rev-parse HEAD 2>/dev/null) || head=
+if [ -n "$head" ] && [ -n "$released" ] && [ "$head" != "$released" ]; then
+  fallback "this checkout is $(echo "$head" | cut -c1-7) but v$version was released from $(echo "$released" | cut -c1-7) — install with --ref v$version for the prebuilt binary"
+fi
 
 download "$base_url/v$version/$asset" "$tmpdir/$asset" || fallback "no prebuilt binary published for v$version ($asset)"
 download "$base_url/v$version/SHA256SUMS" "$tmpdir/SHA256SUMS" || fallback "no checksums published for v$version"

--- a/scripts/fetch-or-build.sh
+++ b/scripts/fetch-or-build.sh
@@ -70,13 +70,14 @@ trap 'rm -rf "$tmpdir"' EXIT
 # without tags, so `git describe` can never answer this; the release stamps its
 # commit in COMMIT and we compare that against HEAD. A missing COMMIT means a
 # release published before stamping, and in that window HEAD is not the tag
-# either, so treating it as a mismatch is the right answer, not a gap to close.
+# either, so an absent or empty stamp is deliberately treated as a mismatch.
 download "$base_url/v$version/COMMIT" "$tmpdir/COMMIT" || fallback "no prebuilt binary published for v$version (no commit stamp)"
 released=$(tr -d ' \t\r\n' < "$tmpdir/COMMIT")
+[ -n "$released" ] || fallback "v$version's commit stamp is empty"
 # No git metadata means this is not a herdr install (that clones; `plugin link`
 # skips [[build]]), so there is nothing to compare HEAD against.
 head=$(git -C "$repo_root" rev-parse HEAD 2>/dev/null) || head=
-if [ -n "$head" ] && [ -n "$released" ] && [ "$head" != "$released" ]; then
+if [ -n "$head" ] && [ "$head" != "$released" ]; then
   fallback "this checkout is $(echo "$head" | cut -c1-7) but v$version was released from $(echo "$released" | cut -c1-7) — install with --ref v$version for the prebuilt binary"
 fi
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -25,6 +25,8 @@ sed "/^\[package\]/,/^\[/ s/^version = .*/version = \"$version\"/" Cargo.toml > 
 mv Cargo.toml.tmp Cargo.toml
 sed "s/^version = .*/version = \"$version\"/" herdr-plugin.toml > herdr-plugin.toml.tmp
 mv herdr-plugin.toml.tmp herdr-plugin.toml
+sed "s|^herdr plugin install andybarilla/herdr-scuttlebutt --ref v.*|herdr plugin install andybarilla/herdr-scuttlebutt --ref v$version|" README.md > README.md.tmp
+mv README.md.tmp README.md
 
 cargo update -p scuttlebutt
 "$script_dir/check-versions.sh" >/dev/null


### PR DESCRIPTION
Closes #20.

`fetch-or-build.sh` read the version out of `Cargo.toml` and downloaded that release's binary, so a clone of main between a release and the next version bump got the **older released binary** at `target/release/scuttlebutt` — silently, since the download succeeded.

## What changed

- The release workflow writes the commit it was built from to a `COMMIT` asset (from `version-guard`'s checkout, so it is the commit the tag resolves to).
- `fetch-or-build.sh` fetches `COMMIT` before the tarball and builds from source when `git rev-parse HEAD` is anything else. A missing or empty `COMMIT` (a release published before stamping) is treated as a mismatch — in that window HEAD is not the tag either, so source-build is the right answer.
- README's install command carries the release tag, since without `--ref` the documented path now builds from source and would hard-fail on a machine without Rust. `release.sh` rewrites it with the other version bumps and `check-versions.sh` checks it, so it can't rot.

## Not the check the issue proposed

The issue's option 2 was `git describe --exact-match --tags`. That can never pass: herdr installs with a shallow, tagless clone. In the live install at `~/.config/herdr/plugins/github/andybarilla.scuttlebutt-afb04b39a6cf`, `git describe --tags` says `fatal: No names found` and `git tag` is empty — so that check would have permanently disabled prebuilts. Comparing HEAD against a stamped commit works in a shallow clone.

## Verified

Against a local fixture release (`SCUTTLEBUTT_BASE_URL` pointed at a file:// dir whose `COMMIT` holds `aa7298d`, the commit `v0.2.1` was really released from — confirmed lightweight tag via the GitHub API):

```
=== ACCEPT: HEAD aa7298d, Cargo.toml 0.2.1 ===
scuttlebutt: installed prebuilt v0.2.1 (x86_64-unknown-linux-gnu), verified SHA-256.

=== REFUSE: HEAD 5a31672, Cargo.toml 0.2.1 ===
scuttlebutt: this checkout is 5a31672 but v0.2.1 was released from aa7298d — install with --ref v0.2.1 for the prebuilt binary — building from source instead.

=== MISSING COMMIT ===
scuttlebutt: no prebuilt binary published for v0.2.1 (no commit stamp) — building from source instead.

=== EMPTY COMMIT ===
scuttlebutt: v0.2.1's commit stamp is empty — building from source instead.
```

The accept case is the exact state of the installed plugin today; the refuse case is this branch's base, which is the bug the issue reports.

## Commit stamp in `daemon-status`

Also does the issue's option 3. `build.rs` stamps the commit — the release workflow passes `version-guard`'s sha (same source as the `COMMIT` asset), any other build reads `git rev-parse HEAD`, and a build outside a checkout stamps `unknown` rather than failing. `daemon-status` gains one line:

```
session dir: /home/andy/.config/herdr/plugins/config/andybarilla.scuttlebutt/...
build: 0.2.1 (c8435e3)
running (pid 708089)
```

So a binary that doesn't match the clone it was installed into is readable against what `herdr plugin list` reports. Verified all three stamp sources (git HEAD, `SCUTTLEBUTT_COMMIT` override, no-git build) and that `daemon-ctl.sh`'s `^running`/`^stale` greps are unaffected by the extra line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
