### PR TITLE
Never prompt a pane a human is typing in

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,7 +678,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scuttlebutt"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scuttlebutt"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ under `~/dev/printersrow`.
 ## Install
 
 ```sh
-herdr plugin install andybarilla/herdr-scuttlebutt --ref v0.2.2
+herdr plugin install andybarilla/herdr-scuttlebutt --ref v0.2.3
 ```
 
 The prebuilt binary is only used when the checkout is the commit that release

--- a/README.md
+++ b/README.md
@@ -71,9 +71,11 @@ scuttlebutt tui                   # the chat pane, posting as `human`
 anonymously. `--as <name>` overrides it. `post`, `read`, `agents` and `tui`
 take `--group` to reach a room other than the one your cwd resolves to.
 
-Delivery only happens while herdr reports an agent `idle` or `done`, so a
-working agent is never interrupted. New members are introduced once and start
-at the current tail — no history dump.
+Delivery only happens while herdr reports an agent `idle` or `done` and its
+pane is not focused, so neither a working agent nor a human typing at a pane is
+interrupted. A focused pane is deferred with no timeout: the batch lands intact
+on the first pass after focus moves away. New members are introduced once and
+start at the current tail — no history dump.
 
 A daemon whose binary is replaced under it — an update, a rebuild — restarts
 into the new build between delivery passes. Cursors and intro flags live on

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,7 +1,7 @@
 # herdr-plugin.toml
 id = "andybarilla.scuttlebutt"
 name = "Scuttlebutt"
-version = "0.2.2"
+version = "0.2.3"
 min_herdr_version = "0.7.0"
 description = "Shared chat room for the agents in a herdr session"
 platforms = ["linux", "macos"]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -386,6 +386,7 @@ mod tests {
             pane_id: "w1:p1".into(),
             status: "idle".into(),
             cwd: String::new(),
+            focused: Some(false),
         }]
     }
 
@@ -396,18 +397,21 @@ mod tests {
                 pane_id: "w1:p1".into(),
                 status: "idle".into(),
                 cwd: "/w/alare/api".into(),
+                focused: Some(false),
             },
             AgentInfo {
                 name: "acme-secret-issue".into(),
                 pane_id: "w2:p1".into(),
                 status: "idle".into(),
                 cwd: "/w/acme/web".into(),
+                focused: Some(false),
             },
             AgentInfo {
                 name: "stray".into(),
                 pane_id: "w3:p1".into(),
                 status: "idle".into(),
                 cwd: "/tmp/scratch".into(),
+                focused: Some(false),
             },
         ]
     }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -857,16 +857,22 @@ pub fn tick(
         // Reported here, above the `introduced` early-continue, because the
         // steady state for every agent is introduced: a warning any lower
         // would never fire for the agents it is about.
-        if a.focused.is_none() && state.focus_unknown_warned.insert(a.name.clone()) {
-            report(
-                dir,
-                &format!(
-                    "[scuttlebutt] herdr reported {} without a `focused` field; \
-                     delivering anyway, so a batch may land in a pane someone \
-                     is typing in",
-                    a.name
-                ),
-            );
+        if a.focused.is_none() {
+            if state.focus_unknown_warned.insert(a.name.clone()) {
+                report(
+                    dir,
+                    &format!(
+                        "[scuttlebutt] herdr reported {} without a `focused` field; \
+                         delivering anyway, so a batch may land in a pane someone \
+                         is typing in",
+                        a.name
+                    ),
+                );
+            }
+        } else {
+            // Once per episode, not once per state file: a herdr that drops
+            // the field, recovers and drops it again must warn both times.
+            state.focus_unknown_warned.remove(&a.name);
         }
         if state.introduced.contains(&a.name) {
             continue;
@@ -1180,6 +1186,48 @@ mod tests {
             "log was: {log}"
         );
         assert!(log.contains("reviewer"), "log was: {log}");
+    }
+
+    #[test]
+    fn a_recovered_focused_field_rearms_the_warning() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = DaemonState::default();
+        introduced(&mut state, &["reviewer"]);
+        state.cursors.insert("reviewer".into(), 0);
+
+        let blind = FakeHerd::focused(vec![("reviewer", "idle", None)]);
+        let seeing = FakeHerd::focused(vec![("reviewer", "idle", Some(false))]);
+        tick(
+            &mut state,
+            &blind,
+            dir.path(),
+            &AgentFilter::default(),
+            None,
+        )
+        .unwrap();
+        tick(
+            &mut state,
+            &seeing,
+            dir.path(),
+            &AgentFilter::default(),
+            None,
+        )
+        .unwrap();
+        tick(
+            &mut state,
+            &blind,
+            dir.path(),
+            &AgentFilter::default(),
+            None,
+        )
+        .unwrap();
+
+        let log = daemon_log(dir.path());
+        assert_eq!(
+            log.matches("without a `focused` field").count(),
+            2,
+            "a second outage went unreported: {log}"
+        );
     }
 
     fn introduced(state: &mut DaemonState, names: &[&str]) {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -795,13 +795,28 @@ pub fn intro_text(exe: &str, group: Option<&str>) -> String {
          To catch up: {exe} read\n\
          To see who's here: {exe} agents\n\
          New messages from others are delivered to you automatically when \
-         you are idle; a message you already saw via `read` may be delivered \
-         again.\n{length_rule} No action needed now."
+         you are idle and your pane is not the one you are typing in; a \
+         message you already saw via `read` may be delivered again.\n\
+         {length_rule} No action needed now."
     )
 }
 
 fn deliverable(status: &str) -> bool {
     status == "idle" || status == "done"
+}
+
+/// Whether delivery must be withheld because a human is at this pane. A pane
+/// someone is typing in reports `idle`, so `agent_status` alone cannot tell
+/// the two apart and `herdr agent prompt` pastes into what they are composing.
+///
+/// Deferred with no timeout: the cursor advances only after a successful
+/// prompt, so the batch lands intact on the first tick after focus moves.
+///
+/// An absent `focused` field fails open. Failing closed would silently freeze
+/// the whole room the day herdr stopped emitting it, and nobody would notice
+/// the absence of messages; a stray paste announces itself immediately.
+fn focus_blocked(a: &AgentInfo) -> bool {
+    a.focused == Some(true)
 }
 
 /// Consecutive absences from `herdr agent list` tolerated before an agent's
@@ -839,13 +854,27 @@ pub fn tick(
     for a in &agents {
         state.cursors.entry(a.name.clone()).or_insert(tail);
         state.absences.remove(&a.name);
+        // Reported here, above the `introduced` early-continue, because the
+        // steady state for every agent is introduced: a warning any lower
+        // would never fire for the agents it is about.
+        if a.focused.is_none() && state.focus_unknown_warned.insert(a.name.clone()) {
+            report(
+                dir,
+                &format!(
+                    "[scuttlebutt] herdr reported {} without a `focused` field; \
+                     delivering anyway, so a batch may land in a pane someone \
+                     is typing in",
+                    a.name
+                ),
+            );
+        }
         if state.introduced.contains(&a.name) {
             continue;
         }
         // Track the deliverable streak here rather than in the delivery loop
         // below, which skips non-deliverable agents entirely and so would
         // never reset the streak.
-        if deliverable(&a.status) {
+        if deliverable(&a.status) && !focus_blocked(a) {
             *state.deliverable_streak.entry(a.name.clone()).or_insert(0) += 1;
         } else {
             state.deliverable_streak.remove(&a.name);
@@ -863,6 +892,7 @@ pub fn tick(
         .chain(state.absences.keys().cloned())
         .chain(state.deliverable_streak.keys().cloned())
         .chain(state.intro_fails.keys().cloned())
+        .chain(state.focus_unknown_warned.iter().cloned())
         .collect();
     for name in known {
         if live.contains(&name) {
@@ -877,11 +907,12 @@ pub fn tick(
             state.absences.remove(&name);
             state.deliverable_streak.remove(&name);
             state.intro_fails.remove(&name);
+            state.focus_unknown_warned.remove(&name);
         }
     }
 
     for a in &agents {
-        if !deliverable(&a.status) {
+        if !deliverable(&a.status) || focus_blocked(a) {
             continue;
         }
         if !state.introduced.contains(&a.name) {
@@ -1018,6 +1049,7 @@ mod tests {
                         pane_id: format!("w1:{n}"),
                         status: s.into(),
                         cwd: String::new(),
+                        focused: Some(false),
                     })
                     .collect(),
                 prompts: RefCell::new(vec![]),
@@ -1041,6 +1073,113 @@ mod tests {
             self.prompts.borrow_mut().push((name.into(), text.into()));
             Ok(())
         }
+    }
+
+    impl FakeHerd {
+        /// `new` with explicit per-agent focus. `None` models a herdr that
+        /// does not emit the field at all.
+        fn focused(agents: Vec<(&str, &str, Option<bool>)>) -> Self {
+            let mut h = FakeHerd::new(agents.iter().map(|(n, s, _)| (*n, *s)).collect());
+            for (a, (_, _, f)) in h.agents.iter_mut().zip(agents) {
+                a.focused = f;
+            }
+            h
+        }
+    }
+
+    fn daemon_log(dir: &Path) -> String {
+        std::fs::read_to_string(dir.join("daemon.log")).unwrap_or_default()
+    }
+
+    #[test]
+    fn a_focused_pane_gets_no_batch() {
+        // The bug: a human typing at an idle pane reads as deliverable, so
+        // `herdr agent prompt` pastes the batch into what they are composing.
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = DaemonState::default();
+        introduced(&mut state, &["reviewer"]);
+        state.cursors.insert("reviewer".into(), 0);
+        append(dir.path(), "human", "hello").unwrap();
+
+        let herd = FakeHerd::focused(vec![("reviewer", "idle", Some(true))]);
+        tick(&mut state, &herd, dir.path(), &AgentFilter::default(), None).unwrap();
+        assert!(
+            herd.prompts.borrow().is_empty(),
+            "pasted into a focused pane: {:?}",
+            herd.prompts.borrow()
+        );
+        // Deferred, not dropped: the cursor must not have advanced.
+        assert_eq!(state.cursors["reviewer"], 0);
+    }
+
+    #[test]
+    fn a_focused_pane_gets_no_intro_and_its_streak_is_cleared() {
+        // The intro is one-shot — delivering it into a focused pane would
+        // mark the agent introduced having never seen the instructions.
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = DaemonState::default();
+        let herd = FakeHerd::focused(vec![("reviewer", "idle", Some(true))]);
+        for _ in 0..REQUIRED_SIGHTINGS + 1 {
+            tick(&mut state, &herd, dir.path(), &AgentFilter::default(), None).unwrap();
+        }
+        assert!(herd.prompts.borrow().is_empty());
+        assert!(!state.introduced.contains("reviewer"));
+        // A focused pane is not a settled PTY, so the streak breaks rather
+        // than accumulating behind the block.
+        assert_eq!(state.deliverable_streak.get("reviewer"), None);
+    }
+
+    #[test]
+    fn the_withheld_batch_arrives_in_full_once_focus_clears() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = DaemonState::default();
+        introduced(&mut state, &["reviewer"]);
+        state.cursors.insert("reviewer".into(), 0);
+
+        let busy = FakeHerd::focused(vec![("reviewer", "idle", Some(true))]);
+        append(dir.path(), "human", "first").unwrap();
+        tick(&mut state, &busy, dir.path(), &AgentFilter::default(), None).unwrap();
+        append(dir.path(), "human", "second").unwrap();
+        tick(&mut state, &busy, dir.path(), &AgentFilter::default(), None).unwrap();
+        assert!(busy.prompts.borrow().is_empty());
+
+        let free = FakeHerd::focused(vec![("reviewer", "idle", Some(false))]);
+        tick(&mut state, &free, dir.path(), &AgentFilter::default(), None).unwrap();
+        let prompts = free.prompts.borrow();
+        assert_eq!(prompts.len(), 1);
+        let body = &prompts[0].1;
+        assert!(body.contains("first"), "{body}");
+        assert!(body.contains("second"), "{body}");
+        assert!(
+            body.find("first").unwrap() < body.find("second").unwrap(),
+            "out of order: {body}"
+        );
+        assert_eq!(state.cursors["reviewer"], 2);
+    }
+
+    #[test]
+    fn a_missing_focused_field_delivers_and_is_logged_once() {
+        // Fail open: a herdr that stops emitting `focused` must not freeze
+        // the room silently. The warning is per-agent, not per-tick — this
+        // path runs every ~2s.
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = DaemonState::default();
+        introduced(&mut state, &["reviewer"]);
+        state.cursors.insert("reviewer".into(), 0);
+        append(dir.path(), "human", "hello").unwrap();
+
+        let herd = FakeHerd::focused(vec![("reviewer", "idle", None)]);
+        for _ in 0..3 {
+            tick(&mut state, &herd, dir.path(), &AgentFilter::default(), None).unwrap();
+        }
+        assert_eq!(herd.prompts.borrow().len(), 1);
+        let log = daemon_log(dir.path());
+        assert_eq!(
+            log.matches("without a `focused` field").count(),
+            1,
+            "log was: {log}"
+        );
+        assert!(log.contains("reviewer"), "log was: {log}");
     }
 
     fn introduced(state: &mut DaemonState, names: &[&str]) {
@@ -1686,6 +1825,7 @@ mod tests {
             pane_id: format!("w1:{name}"),
             status: status.into(),
             cwd: cwd.into(),
+            focused: Some(false),
         }
     }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -795,8 +795,8 @@ pub fn intro_text(exe: &str, group: Option<&str>) -> String {
          To catch up: {exe} read\n\
          To see who's here: {exe} agents\n\
          New messages from others are delivered to you automatically when \
-         you are idle and your pane is not the one you are typing in; a \
-         message you already saw via `read` may be delivered again.\n\
+         you are idle and nobody is typing at your pane; a message you \
+         already saw via `read` may be delivered again.\n\
          {length_rule} No action needed now."
     )
 }
@@ -1084,7 +1084,7 @@ mod tests {
     impl FakeHerd {
         /// `new` with explicit per-agent focus. `None` models a herdr that
         /// does not emit the field at all.
-        fn focused(agents: Vec<(&str, &str, Option<bool>)>) -> Self {
+        fn with_focus(agents: Vec<(&str, &str, Option<bool>)>) -> Self {
             let mut h = FakeHerd::new(agents.iter().map(|(n, s, _)| (*n, *s)).collect());
             for (a, (_, _, f)) in h.agents.iter_mut().zip(agents) {
                 a.focused = f;
@@ -1107,7 +1107,7 @@ mod tests {
         state.cursors.insert("reviewer".into(), 0);
         append(dir.path(), "human", "hello").unwrap();
 
-        let herd = FakeHerd::focused(vec![("reviewer", "idle", Some(true))]);
+        let herd = FakeHerd::with_focus(vec![("reviewer", "idle", Some(true))]);
         tick(&mut state, &herd, dir.path(), &AgentFilter::default(), None).unwrap();
         assert!(
             herd.prompts.borrow().is_empty(),
@@ -1119,20 +1119,58 @@ mod tests {
     }
 
     #[test]
-    fn a_focused_pane_gets_no_intro_and_its_streak_is_cleared() {
+    fn a_focused_pane_gets_no_intro() {
         // The intro is one-shot — delivering it into a focused pane would
         // mark the agent introduced having never seen the instructions.
         let dir = tempfile::tempdir().unwrap();
         let mut state = DaemonState::default();
-        let herd = FakeHerd::focused(vec![("reviewer", "idle", Some(true))]);
+        let herd = FakeHerd::with_focus(vec![("reviewer", "idle", Some(true))]);
         for _ in 0..REQUIRED_SIGHTINGS + 1 {
             tick(&mut state, &herd, dir.path(), &AgentFilter::default(), None).unwrap();
         }
         assert!(herd.prompts.borrow().is_empty());
         assert!(!state.introduced.contains("reviewer"));
-        // A focused pane is not a settled PTY, so the streak breaks rather
-        // than accumulating behind the block.
+        // Focused from the first sighting, so there was never a streak to
+        // keep: `a_focus_block_breaks_the_intro_streak` covers the clearing.
         assert_eq!(state.deliverable_streak.get("reviewer"), None);
+    }
+
+    #[test]
+    fn a_focus_block_breaks_the_intro_streak() {
+        // Decision 4 of #23: REQUIRED_SIGHTINGS proves the PTY has settled,
+        // and a focused pane is not settled by that reasoning. So a focus
+        // block must reset the streak, not bank it — otherwise the intro
+        // fires on the very tick focus clears, off sightings taken before
+        // the human sat down.
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = DaemonState::default();
+        let free = FakeHerd::with_focus(vec![("reviewer", "idle", Some(false))]);
+        let busy = FakeHerd::with_focus(vec![("reviewer", "idle", Some(true))]);
+
+        tick(&mut state, &free, dir.path(), &AgentFilter::default(), None).unwrap();
+        assert_eq!(state.deliverable_streak["reviewer"], 1);
+
+        tick(&mut state, &busy, dir.path(), &AgentFilter::default(), None).unwrap();
+        assert_eq!(
+            state.deliverable_streak.get("reviewer"),
+            None,
+            "an accumulated streak survived a focus block"
+        );
+
+        // First tick after focus clears: the streak restarts at 1, so this
+        // must NOT be the intro. Code that banked the streak fires here.
+        tick(&mut state, &free, dir.path(), &AgentFilter::default(), None).unwrap();
+        assert_eq!(state.deliverable_streak["reviewer"], 1);
+        assert!(
+            free.prompts.borrow().is_empty(),
+            "intro fired the instant focus cleared: {:?}",
+            free.prompts.borrow()
+        );
+
+        // Two fresh settled sightings: now it goes out.
+        tick(&mut state, &free, dir.path(), &AgentFilter::default(), None).unwrap();
+        assert_eq!(free.prompts.borrow().len(), 1);
+        assert!(state.introduced.contains("reviewer"));
     }
 
     #[test]
@@ -1142,14 +1180,14 @@ mod tests {
         introduced(&mut state, &["reviewer"]);
         state.cursors.insert("reviewer".into(), 0);
 
-        let busy = FakeHerd::focused(vec![("reviewer", "idle", Some(true))]);
+        let busy = FakeHerd::with_focus(vec![("reviewer", "idle", Some(true))]);
         append(dir.path(), "human", "first").unwrap();
         tick(&mut state, &busy, dir.path(), &AgentFilter::default(), None).unwrap();
         append(dir.path(), "human", "second").unwrap();
         tick(&mut state, &busy, dir.path(), &AgentFilter::default(), None).unwrap();
         assert!(busy.prompts.borrow().is_empty());
 
-        let free = FakeHerd::focused(vec![("reviewer", "idle", Some(false))]);
+        let free = FakeHerd::with_focus(vec![("reviewer", "idle", Some(false))]);
         tick(&mut state, &free, dir.path(), &AgentFilter::default(), None).unwrap();
         let prompts = free.prompts.borrow();
         assert_eq!(prompts.len(), 1);
@@ -1174,7 +1212,7 @@ mod tests {
         state.cursors.insert("reviewer".into(), 0);
         append(dir.path(), "human", "hello").unwrap();
 
-        let herd = FakeHerd::focused(vec![("reviewer", "idle", None)]);
+        let herd = FakeHerd::with_focus(vec![("reviewer", "idle", None)]);
         for _ in 0..3 {
             tick(&mut state, &herd, dir.path(), &AgentFilter::default(), None).unwrap();
         }
@@ -1195,8 +1233,8 @@ mod tests {
         introduced(&mut state, &["reviewer"]);
         state.cursors.insert("reviewer".into(), 0);
 
-        let blind = FakeHerd::focused(vec![("reviewer", "idle", None)]);
-        let seeing = FakeHerd::focused(vec![("reviewer", "idle", Some(false))]);
+        let blind = FakeHerd::with_focus(vec![("reviewer", "idle", None)]);
+        let seeing = FakeHerd::with_focus(vec![("reviewer", "idle", Some(false))]);
         tick(
             &mut state,
             &blind,

--- a/src/herd.rs
+++ b/src/herd.rs
@@ -8,7 +8,7 @@ pub struct AgentInfo {
     pub cwd: String,
     /// Whether the human's cursor is in this agent's pane. `None` means
     /// `herdr agent list` did not emit the field at all, which is treated as
-    /// "not focused" at the delivery gate — see `deliverable` in `daemon.rs`.
+    /// "not focused" at the delivery gate — see `focus_blocked` in `daemon.rs`.
     pub focused: Option<bool>,
 }
 

--- a/src/herd.rs
+++ b/src/herd.rs
@@ -6,6 +6,10 @@ pub struct AgentInfo {
     pub pane_id: String,
     pub status: String,
     pub cwd: String,
+    /// Whether the human's cursor is in this agent's pane. `None` means
+    /// `herdr agent list` did not emit the field at all, which is treated as
+    /// "not focused" at the delivery gate — see `deliverable` in `daemon.rs`.
+    pub focused: Option<bool>,
 }
 
 pub trait HerdControl {
@@ -26,6 +30,7 @@ pub fn parse_agent_list(json: &str) -> Result<Vec<AgentInfo>> {
                 pane_id: a["pane_id"].as_str().unwrap_or_default().to_string(),
                 status: a["agent_status"].as_str().unwrap_or("unknown").to_string(),
                 cwd: a["cwd"].as_str().unwrap_or_default().to_string(),
+                focused: a["focused"].as_bool(),
             })
         })
         .collect())
@@ -95,8 +100,8 @@ mod tests {
     use super::*;
 
     const FIXTURE: &str = r#"{"id":"cli:agent:list","result":{"agents":[
-        {"agent":"claude","agent_status":"idle","cwd":"/home/andy/.herdr/worktrees/alare/issue-590","name":"issue-590","pane_id":"w35:p1","tab_id":"w35:t1","workspace_id":"w35"},
-        {"agent":"claude","agent_status":"working","name":"issue-758","pane_id":"w3A:p1","tab_id":"w3A:t1","workspace_id":"w3A"},
+        {"agent":"claude","agent_status":"idle","cwd":"/home/andy/.herdr/worktrees/alare/issue-590","focused":true,"name":"issue-590","pane_id":"w35:p1","tab_id":"w35:t1","workspace_id":"w35"},
+        {"agent":"claude","agent_status":"working","focused":false,"name":"issue-758","pane_id":"w3A:p1","tab_id":"w3A:t1","workspace_id":"w3A"},
         {"agent":"claude","agent_status":"idle","pane_id":"w3E:p2","tab_id":"w3E:t2","workspace_id":"w3E"}
     ],"type":"agent_list"}}"#;
 
@@ -109,6 +114,25 @@ mod tests {
         assert_eq!(agents[0].pane_id, "w35:p1");
         assert_eq!(agents[1].name, "issue-758");
         assert_eq!(agents[1].status, "working");
+    }
+
+    #[test]
+    fn parses_the_focused_flag_both_ways() {
+        let agents = parse_agent_list(FIXTURE).unwrap();
+        assert_eq!(agents[0].focused, Some(true));
+        assert_eq!(agents[1].focused, Some(false));
+    }
+
+    #[test]
+    fn missing_focused_is_none_not_false() {
+        // A herdr that does not emit the field must be distinguishable from
+        // one reporting an unfocused pane: the delivery gate logs the former
+        // once and then delivers anyway.
+        let json = r#"{"result":{"agents":[
+            {"agent_status":"idle","name":"issue-590","pane_id":"w35:p1"}
+        ]}}"#;
+        let agents = parse_agent_list(json).unwrap();
+        assert_eq!(agents[0].focused, None);
     }
 
     #[test]

--- a/src/state.rs
+++ b/src/state.rs
@@ -19,6 +19,10 @@ pub struct DaemonState {
     /// Consecutive intro prompt failures per agent.
     #[serde(default)]
     pub intro_fails: HashMap<String, u32>,
+    /// Agents already reported as missing the `focused` field. The check runs
+    /// every tick; the warning is once per agent.
+    #[serde(default)]
+    pub focus_unknown_warned: HashSet<String>,
 }
 
 pub fn load(dir: &Path) -> DaemonState {

--- a/src/state.rs
+++ b/src/state.rs
@@ -13,14 +13,16 @@ pub struct DaemonState {
     /// Consecutive ticks an enrolled agent has been absent from `herdr agent list`.
     #[serde(default)]
     pub absences: HashMap<String, u32>,
-    /// Consecutive ticks a not-yet-introduced agent has been deliverable.
+    /// Consecutive ticks a not-yet-introduced agent has been deliverable and
+    /// unfocused. Broken by either, so the intro waits for fresh sightings.
     #[serde(default)]
     pub deliverable_streak: HashMap<String, u32>,
     /// Consecutive intro prompt failures per agent.
     #[serde(default)]
     pub intro_fails: HashMap<String, u32>,
-    /// Agents already reported as missing the `focused` field. The check runs
-    /// every tick; the warning is once per agent.
+    /// Agents currently being reported without a `focused` field. The check
+    /// runs every tick; the warning is once per outage, and the entry is
+    /// dropped as soon as the field comes back so a later outage warns again.
     #[serde(default)]
     pub focus_unknown_warned: HashSet<String>,
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -457,6 +457,7 @@ mod tests {
             pane_id: "w1:p1".into(),
             status: "idle".into(),
             cwd: cwd.into(),
+            focused: Some(false),
         }
     }
 


### PR DESCRIPTION
Closes #23. Refs #24.

## The bug

`herdr agent list` emits a per-agent `focused` boolean. `parse_agent_list` built `AgentInfo` from `name`, `pane_id`, `agent_status` and `cwd` only, so `deliverable()` had nothing but `agent_status` to go on. A Claude Code pane with a human typing at it reports `idle`, so `herdr agent prompt` typed a batch into the entry box mid-keystroke.

Reproduced at the `tick()` level with `FakeHerd`: a focused, idle, introduced agent with one pending message got the batch. That is `a_focused_pane_gets_no_batch`, which failed on exactly that assertion before the fix.

## The fix

- `AgentInfo` carries `focused: Option<bool>`; `focus_blocked` gates both the batch loop and the one-shot intro.
- A focus block clears `deliverable_streak` (in the enrollment loop, where the streak is actually counted), so the intro waits for two fresh settled sightings rather than firing the instant focus clears.
- Deferral has no timeout. The cursor advances only inside the `Ok(())` arm, so the withheld batch lands intact and in order on the first tick after focus moves away.
- Pane granularity only — `focused` is already per-agent, so other agents in the same tab or workspace are untouched.
- An absent `focused` field **fails open**: delivery proceeds and `report()` logs once per agent (tracked in `DaemonState::focus_unknown_warned`, purged with the rest of an agent's state). This deliberately departs from `parse_focused_cwd`, which errors on a missing field. Failing closed would freeze the entire room silently the day herdr stopped emitting the field; a stray paste announces itself immediately.
- The ordinary focus defer is silent — that path runs every ~2s for as long as someone sits at a pane.
- `intro_text` and the README no longer claim delivery happens whenever you are idle.

## Tests

Four new in `daemon.rs` (focused pane gets no batch; no intro and streak cleared; full withheld batch in order once focus clears; missing field delivers and logs exactly once over three ticks) and two in `herd.rs` (`focused` present true/false, absent → `None`). `FakeHerd` gained a `focused` constructor; `new` still defaults to `Some(false)` so the existing tests are untouched.

## Release

`scripts/release.sh 0.2.3` is in this PR rather than a separate one (`a9067ae` is the normal pattern). Deliberate one-off: the running daemon is the installed plugin build, so merging alone does not stop the bug for anyone.

## Verification

`cargo fmt --all --check`, `cargo clippy --all-targets --locked -- -D warnings` and `cargo test --locked` (189 passed) all clean locally, plus `scripts/check-versions.sh` → 0.2.3.

## Left open

#24 stays open — reading a pane's unsubmitted input would be the better signal, but herdr does not expose it. Gated on Andy, not on this PR. No commit here carries a closing keyword for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Se4of5zCQ51ajZgcGCfCQf