### PR TITLE
Confirm a prompt was submitted before advancing the cursor

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -492,7 +492,7 @@ mod tests {
         fn list_agents(&self) -> Result<Vec<AgentInfo>> {
             panic!("cmd_post must not consult the herd");
         }
-        fn prompt(&self, _name: &str, _text: &str) -> Result<()> {
+        fn prompt(&self, _name: &str, _text: &str) -> Result<crate::herd::Delivery> {
             panic!("cmd_post must not prompt");
         }
     }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -8,6 +8,9 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, OnceLock};
 
+/// Consecutive non-deliveries of a batch to one agent before it is given up
+/// on. Counted two ways — per batch in `fail_counts`, and across batches in
+/// `unconfirmed_streak` — and either reaching this skips the batch.
 pub const MAX_BATCH_FAILURES: u32 = 5;
 
 /// Which agents this daemon enrolls. The spec's design is auto-enroll, so an
@@ -599,8 +602,8 @@ fn run_once(
         // there is no single in-memory state to carry. Consequence: while
         // `state::save` keeps failing (disk full, permissions) each pass
         // re-derives from the last state that reached disk, so the same batch
-        // is delivered again every pass and `fail_counts` never survives to
-        // reach the 5-failure cap.
+        // is delivered again every pass and neither `fail_counts` nor
+        // `unconfirmed_streak` survives to reach the 5-failure cap.
         let mut st = crate::state::load(&dir);
         let scoped = ScopedHerd {
             inner: herd,
@@ -829,17 +832,27 @@ const MAX_ABSENCES: u32 = 3;
 /// from being permanently marked introduced without ever seeing the intro.
 const REQUIRED_SIGHTINGS: u32 = 2;
 
-/// Why a prompt did not reach the agent, or `None` when it did. An `Ok` that
-/// herdr could not confirm as submitted is a non-delivery like any other: the
-/// text is sitting on the agent's composer, unread, and advancing the cursor
-/// on it drops the batch permanently (#26). Both kinds feed one failure
-/// counter, so a pane that can never be confirmed degrades into the existing
-/// skip threshold instead of stalling the room.
-fn undelivered(outcome: Result<Delivery>) -> Option<String> {
+/// A prompt that did not reach the agent. An `Ok` herdr could not confirm as
+/// submitted is a non-delivery like any other — the text is sitting on the
+/// agent's composer, unread, and advancing the cursor on it drops the batch
+/// permanently (#26) — but the two kinds converge differently, so which one
+/// it was has to survive.
+struct NotDelivered {
+    why: String,
+    unconfirmed: bool,
+}
+
+fn undelivered(outcome: Result<Delivery>) -> Option<NotDelivered> {
     match outcome {
         Ok(Delivery::Submitted) => None,
-        Ok(Delivery::Unconfirmed(why)) => Some(format!("was not confirmed submitted: {why}")),
-        Err(e) => Some(format!("failed: {e}")),
+        Ok(Delivery::Unconfirmed(why)) => Some(NotDelivered {
+            why: format!("was not confirmed submitted: {why}"),
+            unconfirmed: true,
+        }),
+        Err(e) => Some(NotDelivered {
+            why: format!("failed: {e}"),
+            unconfirmed: false,
+        }),
     }
 }
 
@@ -909,6 +922,7 @@ pub fn tick(
         .cloned()
         .chain(state.introduced.iter().cloned())
         .chain(state.fail_counts.keys().cloned())
+        .chain(state.unconfirmed_streak.keys().cloned())
         .chain(state.absences.keys().cloned())
         .chain(state.deliverable_streak.keys().cloned())
         .chain(state.intro_fails.keys().cloned())
@@ -924,6 +938,7 @@ pub fn tick(
             state.cursors.remove(&name);
             state.introduced.remove(&name);
             state.fail_counts.remove(&name);
+            state.unconfirmed_streak.remove(&name);
             state.absences.remove(&name);
             state.deliverable_streak.remove(&name);
             state.intro_fails.remove(&name);
@@ -954,7 +969,7 @@ pub fn tick(
                     state.intro_fails.remove(&a.name);
                     state.deliverable_streak.remove(&a.name);
                 }
-                Some(why) => {
+                Some(NotDelivered { why, .. }) => {
                     let fails = state.intro_fails.entry(a.name.clone()).or_insert(0);
                     *fails += 1;
                     let fails = *fails;
@@ -1007,8 +1022,9 @@ pub fn tick(
             None => {
                 state.cursors.insert(a.name.clone(), max_id);
                 state.fail_counts.remove(&a.name);
+                state.unconfirmed_streak.remove(&a.name);
             }
-            Some(why) => {
+            Some(NotDelivered { why, unconfirmed }) => {
                 let entry = state
                     .fail_counts
                     .entry(a.name.clone())
@@ -1020,14 +1036,27 @@ pub fn tick(
                 }
                 entry.0 += 1;
                 let fails = entry.0;
+                // Batch-independent, so a room busy enough to grow the batch
+                // every tick cannot keep an unconfirmable agent below the
+                // threshold forever.
+                let streak = match unconfirmed {
+                    true => {
+                        let s = state.unconfirmed_streak.entry(a.name.clone()).or_insert(0);
+                        *s += 1;
+                        *s
+                    }
+                    false => 0,
+                };
                 report(
                     dir,
                     &format!(
-                        "[scuttlebutt] delivery to {} {why} ({fails}/{MAX_BATCH_FAILURES})",
+                        "[scuttlebutt] delivery to {} {why} \
+                         (batch {fails}/{MAX_BATCH_FAILURES}, \
+                         unconfirmed {streak}/{MAX_BATCH_FAILURES})",
                         a.name
                     ),
                 );
-                if fails >= MAX_BATCH_FAILURES {
+                if fails >= MAX_BATCH_FAILURES || streak >= MAX_BATCH_FAILURES {
                     report(
                         dir,
                         &format!(
@@ -1038,6 +1067,7 @@ pub fn tick(
                     );
                     state.cursors.insert(a.name.clone(), max_id);
                     state.fail_counts.remove(&a.name);
+                    state.unconfirmed_streak.remove(&a.name);
                 }
             }
         }
@@ -1108,6 +1138,14 @@ mod tests {
     }
 
     impl FakeHerd {
+        /// `new` for agents already built with a cwd, so the grouping tests
+        /// do not each have to spell out every field.
+        fn of(agents: Vec<AgentInfo>) -> Self {
+            let mut h = FakeHerd::new(vec![]);
+            h.agents = agents;
+            h
+        }
+
         /// `new` with explicit per-agent focus. `None` models a herdr that
         /// does not emit the field at all.
         fn with_focus(agents: Vec<(&str, &str, Option<bool>)>) -> Self {
@@ -1737,6 +1775,56 @@ mod tests {
             log.contains("SKIPPING batch up to #1 for reviewer"),
             "log was: {log}"
         );
+    }
+
+    #[test]
+    fn an_unconfirmable_agent_converges_while_the_room_is_busy() {
+        // The room this runs in gets traffic faster than five ticks, so the
+        // batch max id changes every pass and `fail_counts`' streak restarts
+        // every pass. Without a batch-independent counter the agent is
+        // re-prompted forever and never reaches the skip.
+        let dir = tempfile::tempdir().unwrap();
+        let herd = unconfirmed_for(&["reviewer"], vec![("reviewer", "idle")]);
+        let mut state = DaemonState::default();
+        introduced(&mut state, &["reviewer"]);
+        state.cursors.insert("reviewer".into(), 0);
+
+        for i in 0..MAX_BATCH_FAILURES {
+            append(dir.path(), "human", &format!("message {i}")).unwrap();
+            tick(&mut state, &herd, dir.path(), &AgentFilter::default(), None).unwrap();
+            // the per-batch counter never gets past its first failure
+            let batch_fails = state.fail_counts.get("reviewer").map(|e| e.0);
+            match i + 1 < MAX_BATCH_FAILURES {
+                true => assert_eq!(batch_fails, Some(1)),
+                // cleared by the skip on the last pass
+                false => assert_eq!(batch_fails, None),
+            }
+        }
+        let tail = u64::from(MAX_BATCH_FAILURES);
+        assert_eq!(state.cursors["reviewer"], tail, "never converged");
+        assert_eq!(state.unconfirmed_streak.get("reviewer"), None);
+        let log = daemon_log(dir.path());
+        assert!(
+            log.contains(&format!("SKIPPING batch up to #{tail} for reviewer")),
+            "log was: {log}"
+        );
+    }
+
+    #[test]
+    fn a_hard_prompt_error_does_not_feed_the_unconfirmed_streak() {
+        // An outright error means herdr rejected the write; a bigger batch on
+        // the next pass is worth another try, which is the per-batch
+        // behaviour `new_message_resets_fail_streak_for_batch` pins down.
+        let dir = tempfile::tempdir().unwrap();
+        let mut herd = FakeHerd::new(vec![("reviewer", "idle")]);
+        herd.fail_prompts = true;
+        let mut state = DaemonState::default();
+        introduced(&mut state, &["reviewer"]);
+        state.cursors.insert("reviewer".into(), 0);
+        append(dir.path(), "human", "hello").unwrap();
+        tick(&mut state, &herd, dir.path(), &AgentFilter::default(), None).unwrap();
+        assert_eq!(state.fail_counts["reviewer"].0, 1);
+        assert_eq!(state.unconfirmed_streak.get("reviewer"), None);
     }
 
     #[test]
@@ -2398,16 +2486,10 @@ mod tests {
             Ok(d)
         };
 
-        let herd = FakeHerd {
-            agents: vec![
-                agent_at("a1", "/w/alare/api", "idle"),
-                agent_at("b1", "/w/acme/web", "idle"),
-            ],
-            prompts: RefCell::new(vec![]),
-            fail_prompts: false,
-            fail_agents: false,
-            unconfirmed: std::collections::HashSet::new(),
-        };
+        let herd = FakeHerd::of(vec![
+            agent_at("a1", "/w/alare/api", "idle"),
+            agent_at("b1", "/w/acme/web", "idle"),
+        ]);
         let mut announced = Announced::default();
         let filter = AgentFilter::default();
 
@@ -2471,16 +2553,10 @@ mod tests {
             std::fs::create_dir_all(&d)?;
             Ok(d)
         };
-        let herd = FakeHerd {
-            agents: vec![
-                agent_at("a1", "/w/alare/api", "idle"),
-                agent_at("b1", "/w/acme/web", "idle"),
-            ],
-            prompts: RefCell::new(vec![]),
-            fail_prompts: false,
-            fail_agents: false,
-            unconfirmed: std::collections::HashSet::new(),
-        };
+        let herd = FakeHerd::of(vec![
+            agent_at("a1", "/w/alare/api", "idle"),
+            agent_at("b1", "/w/acme/web", "idle"),
+        ]);
         let cfg_dir = cfg.clone();
         let load = move || crate::groups::load(&cfg_dir);
         let mut announced = Announced::default();
@@ -2543,23 +2619,11 @@ mod tests {
                 &mut cache,
             );
         };
-        run(&FakeHerd {
-            agents: vec![agent_at("a1", "/w/alare/api", "idle")],
-            prompts: RefCell::new(vec![]),
-            fail_prompts: false,
-            fail_agents: false,
-            unconfirmed: std::collections::HashSet::new(),
-        });
-        run(&FakeHerd {
-            agents: vec![
-                agent_at("a1", "/w/alare/api", "idle"),
-                agent_at("b1", "/w/acme/web", "idle"),
-            ],
-            prompts: RefCell::new(vec![]),
-            fail_prompts: false,
-            fail_agents: false,
-            unconfirmed: std::collections::HashSet::new(),
-        });
+        run(&FakeHerd::of(vec![agent_at("a1", "/w/alare/api", "idle")]));
+        run(&FakeHerd::of(vec![
+            agent_at("a1", "/w/alare/api", "idle"),
+            agent_at("b1", "/w/acme/web", "idle"),
+        ]));
         let log = std::fs::read_to_string(base.path().join("daemon.log")).unwrap();
         assert!(log.contains("enrolling in alare"), "{log}");
         assert!(log.contains("enrolling in acme"), "{log}");
@@ -2579,13 +2643,7 @@ mod tests {
         let mut announced = Announced::default();
         let mut cache = orgs(fake_org);
         let mut run = |cwds: &[(&str, &str)]| {
-            let herd = FakeHerd {
-                agents: cwds.iter().map(|(n, c)| agent_at(n, c, "idle")).collect(),
-                prompts: RefCell::new(vec![]),
-                fail_prompts: false,
-                fail_agents: false,
-                unconfirmed: std::collections::HashSet::new(),
-            };
+            let herd = FakeHerd::of(cwds.iter().map(|(n, c)| agent_at(n, c, "idle")).collect());
             run_once(
                 &herd,
                 &|| Grouping::Inactive,
@@ -2613,13 +2671,7 @@ mod tests {
             std::fs::create_dir_all(&d)?;
             Ok(d)
         };
-        let herd = FakeHerd {
-            agents: vec![agent_at("a1", "/w/alare/api", "idle")],
-            prompts: RefCell::new(vec![]),
-            fail_prompts: false,
-            fail_agents: false,
-            unconfirmed: std::collections::HashSet::new(),
-        };
+        let herd = FakeHerd::of(vec![agent_at("a1", "/w/alare/api", "idle")]);
         let mut announced = Announced::default();
         for _ in 0..REQUIRED_SIGHTINGS + 1 {
             run_once(

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1,5 +1,5 @@
 use crate::groups::{self, Grouping};
-use crate::herd::{AgentInfo, HerdControl};
+use crate::herd::{AgentInfo, Delivery, HerdControl};
 use crate::log_store;
 use crate::state::DaemonState;
 use anyhow::Result;
@@ -499,7 +499,7 @@ impl HerdControl for ScopedHerd<'_> {
     fn list_agents(&self) -> Result<Vec<AgentInfo>> {
         Ok(self.members.clone())
     }
-    fn prompt(&self, name: &str, text: &str) -> Result<()> {
+    fn prompt(&self, name: &str, text: &str) -> Result<Delivery> {
         self.inner.prompt(name, text)
     }
 }
@@ -829,6 +829,20 @@ const MAX_ABSENCES: u32 = 3;
 /// from being permanently marked introduced without ever seeing the intro.
 const REQUIRED_SIGHTINGS: u32 = 2;
 
+/// Why a prompt did not reach the agent, or `None` when it did. An `Ok` that
+/// herdr could not confirm as submitted is a non-delivery like any other: the
+/// text is sitting on the agent's composer, unread, and advancing the cursor
+/// on it drops the batch permanently (#26). Both kinds feed one failure
+/// counter, so a pane that can never be confirmed degrades into the existing
+/// skip threshold instead of stalling the room.
+fn undelivered(outcome: Result<Delivery>) -> Option<String> {
+    match outcome {
+        Ok(Delivery::Submitted) => None,
+        Ok(Delivery::Unconfirmed(why)) => Some(format!("was not confirmed submitted: {why}")),
+        Err(e) => Some(format!("failed: {e}")),
+    }
+}
+
 /// `filter` is vestigial in production: `run_once` applies the agent filter
 /// once, before partitioning, so the only production call site passes
 /// `AgentFilter::default()`. It survives because the tests drive `tick`
@@ -934,20 +948,20 @@ pub fn tick(
             // handed was checked as late as possible: a plugin install can
             // land at any point in the session.
             let exe = crate::paths::command_path();
-            match herd.prompt(&a.name, &intro_text(&exe, group)) {
-                Ok(()) => {
+            match undelivered(herd.prompt(&a.name, &intro_text(&exe, group))) {
+                None => {
                     state.introduced.insert(a.name.clone());
                     state.intro_fails.remove(&a.name);
                     state.deliverable_streak.remove(&a.name);
                 }
-                Err(e) => {
+                Some(why) => {
                     let fails = state.intro_fails.entry(a.name.clone()).or_insert(0);
                     *fails += 1;
                     let fails = *fails;
                     report(
                         dir,
                         &format!(
-                            "[scuttlebutt] intro to {} failed ({fails}/{MAX_BATCH_FAILURES}): {e}",
+                            "[scuttlebutt] intro to {} {why} ({fails}/{MAX_BATCH_FAILURES})",
                             a.name
                         ),
                     );
@@ -989,12 +1003,12 @@ pub fn tick(
             .map(|m| format!("[#{}] {}: {}\n", m.id, scrub_name(&m.from), scrub(&m.text)))
             .collect();
         let text = format!("{DELIVERY_RULE}\n[scuttlebutt] New messages in the room:\n{body}");
-        match herd.prompt(&a.name, &text) {
-            Ok(()) => {
+        match undelivered(herd.prompt(&a.name, &text)) {
+            None => {
                 state.cursors.insert(a.name.clone(), max_id);
                 state.fail_counts.remove(&a.name);
             }
-            Err(e) => {
+            Some(why) => {
                 let entry = state
                     .fail_counts
                     .entry(a.name.clone())
@@ -1009,8 +1023,8 @@ pub fn tick(
                 report(
                     dir,
                     &format!(
-                        "[scuttlebutt] delivery to {} failed ({}/{MAX_BATCH_FAILURES}): {e}",
-                        a.name, fails
+                        "[scuttlebutt] delivery to {} {why} ({fails}/{MAX_BATCH_FAILURES})",
+                        a.name
                     ),
                 );
                 if fails >= MAX_BATCH_FAILURES {
@@ -1043,6 +1057,9 @@ mod tests {
         prompts: RefCell<Vec<(String, String)>>,
         fail_prompts: bool,
         fail_agents: bool,
+        /// Agents whose prompts herdr accepts while leaving the text sitting
+        /// on the composer: `Ok`, but nothing delivered.
+        unconfirmed: std::collections::HashSet<String>,
     }
 
     impl FakeHerd {
@@ -1061,6 +1078,7 @@ mod tests {
                 prompts: RefCell::new(vec![]),
                 fail_prompts: false,
                 fail_agents: false,
+                unconfirmed: std::collections::HashSet::new(),
             }
         }
     }
@@ -1072,12 +1090,20 @@ mod tests {
             }
             Ok(self.agents.clone())
         }
-        fn prompt(&self, name: &str, text: &str) -> anyhow::Result<()> {
+        fn prompt(&self, name: &str, text: &str) -> anyhow::Result<Delivery> {
             if self.fail_prompts {
                 anyhow::bail!("stalled");
             }
+            // Recorded either way: the text reached the pane, which is
+            // exactly why an unconfirmed prompt is indistinguishable from a
+            // delivered one at the call site.
             self.prompts.borrow_mut().push((name.into(), text.into()));
-            Ok(())
+            if self.unconfirmed.contains(name) {
+                return Ok(Delivery::Unconfirmed(
+                    "the text is still on the composer".into(),
+                ));
+            }
+            Ok(Delivery::Submitted)
         }
     }
 
@@ -1632,6 +1658,124 @@ mod tests {
         // after the 5th consecutive failure the batch is skipped
         assert_eq!(state.cursors["reviewer"], 1);
         assert_eq!(state.fail_counts.get("reviewer"), None);
+    }
+
+    /// A prompt herdr accepted while leaving the text on the composer. This
+    /// is the #26 defect: the batch never reached the agent, so treating the
+    /// `Ok` as delivery advances the cursor past messages nobody saw.
+    fn unconfirmed_for(agents: &[&str], statuses: Vec<(&str, &str)>) -> FakeHerd {
+        let mut herd = FakeHerd::new(statuses);
+        herd.unconfirmed = agents.iter().map(|a| a.to_string()).collect();
+        herd
+    }
+
+    #[test]
+    fn an_unconfirmed_prompt_does_not_advance_the_cursor() {
+        let dir = tempfile::tempdir().unwrap();
+        let herd = unconfirmed_for(&["reviewer"], vec![("reviewer", "idle")]);
+        let mut state = DaemonState::default();
+        introduced(&mut state, &["reviewer"]);
+        state.cursors.insert("reviewer".into(), 0);
+        append(dir.path(), "human", "hello").unwrap();
+
+        tick(&mut state, &herd, dir.path(), &AgentFilter::default(), None).unwrap();
+        assert_eq!(
+            state.cursors["reviewer"], 0,
+            "cursor advanced past a batch that never left the composer"
+        );
+        assert_eq!(state.fail_counts["reviewer"], (1, 1));
+
+        // and the same batch is offered again on the next pass
+        tick(&mut state, &herd, dir.path(), &AgentFilter::default(), None).unwrap();
+        let prompts = herd.prompts.borrow();
+        assert_eq!(prompts.len(), 2);
+        assert!(
+            prompts[1].1.contains("hello"),
+            "second pass sent: {:?}",
+            prompts[1].1
+        );
+    }
+
+    #[test]
+    fn a_confirmed_prompt_advances_the_cursor_exactly_once() {
+        let dir = tempfile::tempdir().unwrap();
+        let herd = FakeHerd::new(vec![("reviewer", "idle")]);
+        let mut state = DaemonState::default();
+        introduced(&mut state, &["reviewer"]);
+        state.cursors.insert("reviewer".into(), 0);
+        append(dir.path(), "human", "hello").unwrap();
+
+        tick(&mut state, &herd, dir.path(), &AgentFilter::default(), None).unwrap();
+        tick(&mut state, &herd, dir.path(), &AgentFilter::default(), None).unwrap();
+        assert_eq!(state.cursors["reviewer"], 1);
+        assert_eq!(herd.prompts.borrow().len(), 1, "batch was re-delivered");
+        assert_eq!(state.fail_counts.get("reviewer"), None);
+    }
+
+    #[test]
+    fn repeated_unconfirmed_deliveries_hit_the_skip_threshold() {
+        let dir = tempfile::tempdir().unwrap();
+        let herd = unconfirmed_for(&["reviewer"], vec![("reviewer", "idle")]);
+        let mut state = DaemonState::default();
+        introduced(&mut state, &["reviewer"]);
+        state.cursors.insert("reviewer".into(), 0);
+        append(dir.path(), "human", "hello").unwrap();
+
+        for _ in 0..(MAX_BATCH_FAILURES - 1) {
+            tick(&mut state, &herd, dir.path(), &AgentFilter::default(), None).unwrap();
+        }
+        assert_eq!(state.cursors["reviewer"], 0);
+        assert_eq!(state.fail_counts["reviewer"].0, MAX_BATCH_FAILURES - 1);
+
+        tick(&mut state, &herd, dir.path(), &AgentFilter::default(), None).unwrap();
+        // the room does not stall on one bad pane: give up, loudly, and move on
+        assert_eq!(state.cursors["reviewer"], 1);
+        assert_eq!(state.fail_counts.get("reviewer"), None);
+        let log = daemon_log(dir.path());
+        assert!(log.contains("still on the composer"), "log was: {log}");
+        assert!(
+            log.contains("SKIPPING batch up to #1 for reviewer"),
+            "log was: {log}"
+        );
+    }
+
+    #[test]
+    fn one_unconfirmable_agent_does_not_hold_up_the_others() {
+        let dir = tempfile::tempdir().unwrap();
+        let herd = unconfirmed_for(&["stuck"], vec![("stuck", "idle"), ("reviewer", "idle")]);
+        let mut state = DaemonState::default();
+        introduced(&mut state, &["stuck", "reviewer"]);
+        state.cursors.insert("stuck".into(), 0);
+        state.cursors.insert("reviewer".into(), 0);
+        append(dir.path(), "human", "hello").unwrap();
+
+        tick(&mut state, &herd, dir.path(), &AgentFilter::default(), None).unwrap();
+        assert_eq!(state.cursors["stuck"], 0);
+        assert_eq!(state.cursors["reviewer"], 1);
+        let names: Vec<String> = herd
+            .prompts
+            .borrow()
+            .iter()
+            .map(|(n, _)| n.clone())
+            .collect();
+        assert_eq!(names, vec!["stuck", "reviewer"]);
+    }
+
+    #[test]
+    fn an_unconfirmed_intro_is_not_recorded_as_introduced() {
+        let dir = tempfile::tempdir().unwrap();
+        let herd = unconfirmed_for(&["reviewer"], vec![("reviewer", "idle")]);
+        let mut state = DaemonState::default();
+        state
+            .deliverable_streak
+            .insert("reviewer".into(), REQUIRED_SIGHTINGS);
+
+        tick(&mut state, &herd, dir.path(), &AgentFilter::default(), None).unwrap();
+        assert!(
+            !state.introduced.contains("reviewer"),
+            "introduced on a prompt that never left the composer"
+        );
+        assert_eq!(state.intro_fails["reviewer"], 1);
     }
 
     #[test]
@@ -2260,6 +2404,7 @@ mod tests {
             prompts: RefCell::new(vec![]),
             fail_prompts: false,
             fail_agents: false,
+            unconfirmed: std::collections::HashSet::new(),
         };
         let mut announced = Announced::default();
         let filter = AgentFilter::default();
@@ -2332,6 +2477,7 @@ mod tests {
             prompts: RefCell::new(vec![]),
             fail_prompts: false,
             fail_agents: false,
+            unconfirmed: std::collections::HashSet::new(),
         };
         let cfg_dir = cfg.clone();
         let load = move || crate::groups::load(&cfg_dir);
@@ -2400,6 +2546,7 @@ mod tests {
             prompts: RefCell::new(vec![]),
             fail_prompts: false,
             fail_agents: false,
+            unconfirmed: std::collections::HashSet::new(),
         });
         run(&FakeHerd {
             agents: vec![
@@ -2409,6 +2556,7 @@ mod tests {
             prompts: RefCell::new(vec![]),
             fail_prompts: false,
             fail_agents: false,
+            unconfirmed: std::collections::HashSet::new(),
         });
         let log = std::fs::read_to_string(base.path().join("daemon.log")).unwrap();
         assert!(log.contains("enrolling in alare"), "{log}");
@@ -2434,6 +2582,7 @@ mod tests {
                 prompts: RefCell::new(vec![]),
                 fail_prompts: false,
                 fail_agents: false,
+                unconfirmed: std::collections::HashSet::new(),
             };
             run_once(
                 &herd,
@@ -2467,6 +2616,7 @@ mod tests {
             prompts: RefCell::new(vec![]),
             fail_prompts: false,
             fail_agents: false,
+            unconfirmed: std::collections::HashSet::new(),
         };
         let mut announced = Announced::default();
         for _ in 0..REQUIRED_SIGHTINGS + 1 {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1740,25 +1740,27 @@ mod tests {
     }
 
     #[test]
-    fn one_unconfirmable_agent_does_not_hold_up_the_others() {
-        let dir = tempfile::tempdir().unwrap();
-        let herd = unconfirmed_for(&["stuck"], vec![("stuck", "idle"), ("reviewer", "idle")]);
-        let mut state = DaemonState::default();
-        introduced(&mut state, &["stuck", "reviewer"]);
-        state.cursors.insert("stuck".into(), 0);
-        state.cursors.insert("reviewer".into(), 0);
-        append(dir.path(), "human", "hello").unwrap();
+    fn an_unconfirmable_agent_listed_first_still_lets_the_rest_through() {
+        // Order matters: an unconfirmed delivery that short-circuited the
+        // pass would strand every agent listed after it.
+        for order in [
+            vec![("stuck", "idle"), ("reviewer", "idle")],
+            vec![("reviewer", "idle"), ("stuck", "idle")],
+        ] {
+            let dir = tempfile::tempdir().unwrap();
+            let herd = unconfirmed_for(&["stuck"], order);
+            let mut state = DaemonState::default();
+            introduced(&mut state, &["stuck", "reviewer"]);
+            state.cursors.insert("stuck".into(), 0);
+            state.cursors.insert("reviewer".into(), 0);
+            append(dir.path(), "human", "hello").unwrap();
 
-        tick(&mut state, &herd, dir.path(), &AgentFilter::default(), None).unwrap();
-        assert_eq!(state.cursors["stuck"], 0);
-        assert_eq!(state.cursors["reviewer"], 1);
-        let names: Vec<String> = herd
-            .prompts
-            .borrow()
-            .iter()
-            .map(|(n, _)| n.clone())
-            .collect();
-        assert_eq!(names, vec!["stuck", "reviewer"]);
+            tick(&mut state, &herd, dir.path(), &AgentFilter::default(), None).unwrap();
+            assert_eq!(state.cursors["stuck"], 0);
+            assert_eq!(state.fail_counts["stuck"].0, 1);
+            assert_eq!(state.cursors["reviewer"], 1);
+            assert_eq!(state.fail_counts.get("reviewer"), None);
+        }
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -8,9 +8,11 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, OnceLock};
 
-/// Consecutive non-deliveries of a batch to one agent before it is given up
-/// on. Counted two ways — per batch in `fail_counts`, and across batches in
-/// `unconfirmed_streak` — and either reaching this skips the batch.
+/// Non-deliveries to one agent before its batch is given up on. Two counters
+/// reach it over different events: `fail_counts` counts every non-delivery of
+/// one batch and restarts when the batch grows, while `unconfirmed_streak`
+/// counts only unconfirmed deliveries and ignores the batch. Either reaching
+/// this skips the batch.
 pub const MAX_BATCH_FAILURES: u32 = 5;
 
 /// Which agents this daemon enrolls. The spec's design is auto-enroll, so an
@@ -1038,15 +1040,18 @@ pub fn tick(
                 let fails = entry.0;
                 // Batch-independent, so a room busy enough to grow the batch
                 // every tick cannot keep an unconfirmable agent below the
-                // threshold forever.
-                let streak = match unconfirmed {
-                    true => {
-                        let s = state.unconfirmed_streak.entry(a.name.clone()).or_insert(0);
-                        *s += 1;
-                        *s
-                    }
-                    false => 0,
-                };
+                // threshold forever. Only unconfirmed deliveries advance it,
+                // but the stored value is what gets reported either way: a
+                // hard error in the middle of a streak must not log 0/5 and
+                // make the eventual skip look like it came from nowhere.
+                if unconfirmed {
+                    *state.unconfirmed_streak.entry(a.name.clone()).or_insert(0) += 1;
+                }
+                let streak = state
+                    .unconfirmed_streak
+                    .get(&a.name)
+                    .copied()
+                    .unwrap_or_default();
                 report(
                     dir,
                     &format!(
@@ -1825,6 +1830,28 @@ mod tests {
         tick(&mut state, &herd, dir.path(), &AgentFilter::default(), None).unwrap();
         assert_eq!(state.fail_counts["reviewer"].0, 1);
         assert_eq!(state.unconfirmed_streak.get("reviewer"), None);
+    }
+
+    #[test]
+    fn a_hard_error_mid_streak_reports_the_stored_count() {
+        // Reporting a local 0 here made the skip two ticks later look like it
+        // arrived from nowhere in the daemon log.
+        let dir = tempfile::tempdir().unwrap();
+        let mut herd = unconfirmed_for(&["reviewer"], vec![("reviewer", "idle")]);
+        let mut state = DaemonState::default();
+        introduced(&mut state, &["reviewer"]);
+        state.cursors.insert("reviewer".into(), 0);
+        append(dir.path(), "human", "hello").unwrap();
+        for _ in 0..2 {
+            tick(&mut state, &herd, dir.path(), &AgentFilter::default(), None).unwrap();
+        }
+        herd.fail_prompts = true;
+        tick(&mut state, &herd, dir.path(), &AgentFilter::default(), None).unwrap();
+        let log = daemon_log(dir.path());
+        assert!(
+            log.contains("failed: stalled (batch 3/5, unconfirmed 2/5)"),
+            "log was: {log}"
+        );
     }
 
     #[test]

--- a/src/herd.rs
+++ b/src/herd.rs
@@ -28,15 +28,32 @@ pub trait HerdControl {
     fn prompt(&self, name: &str, text: &str) -> Result<Delivery>;
 }
 
-/// Characters of the sent text matched against the composer. Long enough to
-/// be unique to scuttlebutt's own outgoing text, short enough to survive a
-/// composer that clips the line it is rendered on.
+/// Characters of the sent text matched against the composer.
+///
+/// Deliberately *not* unique to one batch: every batch opens with the same
+/// `DELIVERY_RULE`, so this identifies scuttlebutt's outgoing text in
+/// general, not this particular send. That is sound only because `herdr
+/// agent prompt` replaces the composer contents rather than appending to
+/// them — observed on live panes and recorded on #26 — so text matching the
+/// fingerprint after a prompt can only be the text that prompt just wrote.
+///
+/// If herdr ever appends instead, an older batch left unsent on the composer
+/// would make a genuinely submitted new batch read as unsubmitted. That
+/// costs a repeat delivery and converges on the skip threshold; it does not
+/// lose a batch silently, which is the failure this whole path exists to
+/// prevent. No unit test can guard a third-party invariant, so it is named
+/// here instead.
 const FINGERPRINT_CHARS: usize = 40;
 
 /// How long to let the pane repaint before a second look. Paid only when the
-/// first read found the text still on the composer, which on a healthy pane
-/// means the prompt landed between the write and the snapshot.
+/// first look failed to confirm, which on a healthy pane means the prompt
+/// landed between the write and the snapshot.
 const REREAD_DELAY: std::time::Duration = std::time::Duration::from_millis(400);
+
+/// Consecutive horizontal box-drawing characters that make a line a rule.
+/// Long enough that prose quoting a rule (`"\u{2500}\u{2500}\u{2500} Context \u{2500}\u{2500}\u{2500}"`) is not
+/// mistaken for one.
+const RULE_RUN: usize = 8;
 
 /// Whitespace-insensitive form. The composer wraps at word boundaries and
 /// pads with NBSP, so comparing normalized text matches across both.
@@ -44,41 +61,68 @@ fn normalize(s: &str) -> String {
     s.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
-fn fingerprint(sent: &str) -> String {
-    normalize(sent).chars().take(FINGERPRINT_CHARS).collect()
+/// Least composer text that can be taken for a run of our own. A rule inside
+/// a message body splits the composer region, leaving only the text below it
+/// to match; this is the floor at which that remainder is ours rather than a
+/// short phrase someone happened to type.
+const SPLIT_TAIL_CHARS: usize = 16;
+
+/// Whether `region` is the tail of a composer whose top a rule inside the
+/// message body cut off.
+fn is_split_tail(region: &str, sent: &str) -> bool {
+    region.chars().count() >= SPLIT_TAIL_CHARS && sent.contains(region)
 }
 
-/// A horizontal rule, which is how the composer box is drawn. Box-drawing
-/// characters only: message bodies reach the pane unaltered, so a line of
-/// ASCII `---` in someone's post is content, not furniture.
-fn is_border(line: &str) -> bool {
-    let t = line.trim();
-    !t.is_empty()
-        && t.chars()
-            .all(|c| matches!(c, '\u{2500}' | '\u{2501}' | '\u{2550}'))
+/// A horizontal rule, which is how the composer box is drawn. Any of the
+/// box-drawing horizontals — heavy, double, dashed — counts, since which one
+/// a terminal UI picks is its own business; a run of them is required so that
+/// text merely containing one is content, not furniture.
+fn is_rule(line: &str) -> bool {
+    let mut run = 0;
+    for c in line.chars() {
+        run = match c {
+            // light, heavy, dashed and double horizontals; the horizontal
+            // bar and extension; the block halves a UI may rule with
+            '\u{2500}' | '\u{2501}' | '\u{2504}' | '\u{2505}' | '\u{2508}' | '\u{2509}'
+            | '\u{254c}' | '\u{254d}' | '\u{2550}' | '\u{2015}' | '\u{23af}' | '\u{2580}'
+            | '\u{2581}' | '\u{2584}' | '\u{2594}' => run + 1,
+            _ => 0,
+        };
+        if run >= RULE_RUN {
+            return true;
+        }
+    }
+    false
 }
 
 /// Whether `sent` is sitting unsubmitted on `pane`'s composer — the region
 /// between the last two horizontal rules, below which there is only the
-/// status footer.
+/// status footer. It counts as ours when it opens with our fingerprint, or
+/// when a rule inside a message body cut the top off and only a run of our
+/// own text is left (`is_split_tail`).
 ///
-/// `None` means the composer could not be located, which is itself evidence
-/// against submission: a submitted prompt leaves an empty one-line box with
-/// both rules on screen, while an unsubmitted batch is tall enough to push
-/// its own top rule off it.
+/// `None` means no composer could be located. That is ambiguous rather than
+/// informative: it happens when an unsubmitted batch is tall enough to push
+/// its own top rule off the screen, when a pane draws no composer at all,
+/// and when a rule is drawn some way this does not recognize. The ambiguity
+/// is resolved toward "not submitted" by the caller, because a wrong
+/// `Submitted` drops the batch permanently while a wrong `Unconfirmed` costs
+/// a repeat delivery and converges on the skip threshold.
 fn composer_holds(pane: &str, sent: &str) -> Option<bool> {
     let lines: Vec<&str> = pane.lines().collect();
     let rules: Vec<usize> = lines
         .iter()
         .enumerate()
-        .filter(|(_, l)| is_border(l))
+        .filter(|(_, l)| is_rule(l))
         .map(|(i, _)| i)
         .collect();
     let [.., top, bottom] = rules[..] else {
         return None;
     };
     let region = normalize(&lines[top + 1..bottom].join(" "));
-    Some(region.contains(&fingerprint(sent)))
+    let sent = normalize(sent);
+    let fingerprint: String = sent.chars().take(FINGERPRINT_CHARS).collect();
+    Some(region.contains(&fingerprint) || is_split_tail(&region, &sent))
 }
 
 fn read_pane(name: &str) -> Result<String> {
@@ -99,30 +143,53 @@ fn read_pane(name: &str) -> Result<String> {
     Ok(String::from_utf8(out.stdout)?)
 }
 
-/// Reads `name`'s pane back and reports whether `sent` actually left the
-/// composer.
-fn confirm(name: &str, sent: &str) -> Delivery {
-    match look(name, sent) {
-        // The happy path costs one read and no waiting.
-        Delivery::Submitted => Delivery::Submitted,
-        // A pane that has not repainted yet still shows the text it is about
-        // to submit, so give it a moment and look once more before calling a
-        // delivery undelivered.
-        Delivery::Unconfirmed(_) => {
-            std::thread::sleep(REREAD_DELAY);
-            look(name, sent)
-        }
-    }
+/// Reads a pane back to decide whether a prompt was submitted. The pane read
+/// and the retry delay are fields so the retry, the delay and the error
+/// mapping can be driven without a live herdr.
+struct Confirmer {
+    read: fn(&str) -> Result<String>,
+    delay: std::time::Duration,
 }
 
-fn look(name: &str, sent: &str) -> Delivery {
-    match read_pane(name) {
-        Err(e) => Delivery::Unconfirmed(format!("could not read the pane: {e}")),
-        Ok(pane) => match composer_holds(&pane, sent) {
-            Some(false) => Delivery::Submitted,
-            Some(true) => Delivery::Unconfirmed("the text is still on the composer".into()),
-            None => Delivery::Unconfirmed("no composer found in the pane".into()),
-        },
+impl Confirmer {
+    fn new() -> Self {
+        Confirmer {
+            read: read_pane,
+            delay: REREAD_DELAY,
+        }
+    }
+
+    #[cfg(test)]
+    fn with_read(read: fn(&str) -> Result<String>) -> Self {
+        Confirmer {
+            read,
+            delay: std::time::Duration::ZERO,
+        }
+    }
+
+    fn confirm(&self, name: &str, sent: &str) -> Delivery {
+        match self.look(name, sent) {
+            // The happy path costs one read and no waiting.
+            Delivery::Submitted => Delivery::Submitted,
+            // A pane that has not repainted yet still shows the text it is
+            // about to submit, so give it a moment and look once more before
+            // calling a delivery undelivered.
+            Delivery::Unconfirmed(_) => {
+                std::thread::sleep(self.delay);
+                self.look(name, sent)
+            }
+        }
+    }
+
+    fn look(&self, name: &str, sent: &str) -> Delivery {
+        match (self.read)(name) {
+            Err(e) => Delivery::Unconfirmed(format!("could not read the pane: {e}")),
+            Ok(pane) => match composer_holds(&pane, sent) {
+                Some(false) => Delivery::Submitted,
+                Some(true) => Delivery::Unconfirmed("the text is still on the composer".into()),
+                None => Delivery::Unconfirmed("no composer found in the pane".into()),
+            },
+        }
     }
 }
 
@@ -200,7 +267,7 @@ impl HerdControl for RealHerd {
             "herdr agent prompt {name} failed: {}",
             String::from_utf8_lossy(&out.stderr)
         );
-        Ok(confirm(name, text))
+        Ok(Confirmer::new().confirm(name, text))
     }
 }
 
@@ -378,5 +445,146 @@ mod tests {
             "  acknowledge or repeat.",
         ];
         assert_eq!(composer_holds(&pane(&composer), RULE), Some(true));
+    }
+
+    /// Captured verbatim from `herdr agent read --source visible --format
+    /// text` on a live Claude Code pane, transcript above the composer
+    /// trimmed. `composer-holds-batch` was taken with a real delivery
+    /// preamble typed into the composer and never submitted — the #26 state;
+    /// `composer-empty` is the same pane with the composer cleared. Both
+    /// keep one transcript line quoting box-drawing characters, which is
+    /// what stops `is_rule` from being loosened into matching prose.
+    const HOLDS_BATCH: &str = include_str!("../tests/fixtures/composer-holds-batch.txt");
+    const EMPTY: &str = include_str!("../tests/fixtures/composer-empty.txt");
+
+    #[test]
+    fn a_real_pane_holding_an_unsubmitted_batch_is_not_confirmed() {
+        assert_eq!(composer_holds(HOLDS_BATCH, RULE), Some(true));
+    }
+
+    #[test]
+    fn a_real_pane_with_an_empty_composer_confirms_submission() {
+        assert_eq!(composer_holds(EMPTY, RULE), Some(false));
+    }
+
+    #[test]
+    fn a_real_transcript_line_quoting_a_rule_is_not_a_rule() {
+        // Both fixtures carry a line containing `\u{2500}\u{2500}\u{2500} Context \u{2500}\u{2500}\u{2500}`. Treating it
+        // as furniture would move the composer region up into the transcript.
+        let quoting: Vec<&str> = HOLDS_BATCH
+            .lines()
+            .filter(|l| l.contains('\u{2500}') && !is_rule(l))
+            .collect();
+        assert!(!quoting.is_empty(), "fixture lost its rule-quoting line");
+        assert_eq!(composer_holds(HOLDS_BATCH, RULE), Some(true));
+    }
+
+    #[test]
+    fn heavy_dashed_and_double_rules_are_rules_too() {
+        for c in [
+            '\u{2500}', '\u{2501}', '\u{2504}', '\u{254c}', '\u{2550}', '\u{2015}', '\u{2581}',
+        ] {
+            let r = c.to_string().repeat(RULE_RUN);
+            assert!(is_rule(&r), "{c:?} run not recognized");
+        }
+        // a rule with corners, and a titled rule, both still read as rules
+        assert!(is_rule(&format!(
+            "\u{250c}{}\u{2510}",
+            "\u{2500}".repeat(20)
+        )));
+        assert!(is_rule(&format!(
+            "{} Context {}",
+            "\u{2500}".repeat(10),
+            "\u{2500}".repeat(10)
+        )));
+        // and a short run in prose is not
+        assert!(!is_rule(
+            "like \"\u{2500}\u{2500}\u{2500} Context \u{2500}\u{2500}\u{2500}\", dashed variants"
+        ));
+    }
+
+    #[test]
+    fn a_rule_inside_a_message_body_does_not_hide_the_batch() {
+        // A room message can contain a rule of its own. It splits the
+        // composer region, leaving only the text after it — which the tail
+        // fingerprint still matches.
+        let sent = format!("{RULE}\n[scuttlebutt] New messages in the room:\n[#1] a: {}\nthe last line of the batch", "\u{2500}".repeat(30));
+        let composer = [
+            "\u{276f} Reply only if you have information others don't",
+            "  [scuttlebutt] New messages in the room:",
+            "  [#1] a:",
+            &"\u{2500}".repeat(30),
+            "  the last line of the batch",
+        ];
+        assert_eq!(composer_holds(&pane(&composer), &sent), Some(true));
+    }
+
+    fn ok_pane(_: &str) -> Result<String> {
+        Ok(EMPTY.to_string())
+    }
+
+    fn unreadable(_: &str) -> Result<String> {
+        anyhow::bail!("agent target gone not found")
+    }
+
+    #[test]
+    fn a_confirmed_first_look_costs_no_retry() {
+        assert_eq!(
+            Confirmer::with_read(ok_pane).confirm("reviewer", RULE),
+            Delivery::Submitted
+        );
+    }
+
+    #[test]
+    fn a_pane_that_repaints_between_looks_confirms_on_the_second() {
+        // The first snapshot catches the text still on the composer because
+        // the pane has not repainted yet. Retrying is what keeps a healthy
+        // delivery from being reported as undelivered.
+        fn repainting(_: &str) -> Result<String> {
+            use std::sync::atomic::{AtomicUsize, Ordering};
+            static LOOKS: AtomicUsize = AtomicUsize::new(0);
+            Ok(match LOOKS.fetch_add(1, Ordering::SeqCst) {
+                0 => HOLDS_BATCH.to_string(),
+                _ => EMPTY.to_string(),
+            })
+        }
+        assert_eq!(
+            Confirmer::with_read(repainting).confirm("reviewer", RULE),
+            Delivery::Submitted
+        );
+    }
+
+    #[test]
+    fn text_still_on_the_composer_after_both_looks_is_unconfirmed() {
+        fn stuck(_: &str) -> Result<String> {
+            Ok(HOLDS_BATCH.to_string())
+        }
+        assert_eq!(
+            Confirmer::with_read(stuck).confirm("reviewer", RULE),
+            Delivery::Unconfirmed("the text is still on the composer".into())
+        );
+    }
+
+    #[test]
+    fn an_unreadable_pane_is_unconfirmed_and_names_the_cause() {
+        // The agent's pane closed between the prompt and the read: nothing
+        // was delivered, and the operator needs to see why.
+        let Delivery::Unconfirmed(why) = Confirmer::with_read(unreadable).confirm("gone", RULE)
+        else {
+            panic!("an unreadable pane confirmed a delivery");
+        };
+        assert!(why.contains("could not read the pane"), "why was: {why}");
+        assert!(why.contains("not found"), "why was: {why}");
+    }
+
+    #[test]
+    fn a_pane_with_no_composer_is_unconfirmed() {
+        fn no_composer(_: &str) -> Result<String> {
+            Ok("a plain shell with no composer at all\n$ ".to_string())
+        }
+        assert_eq!(
+            Confirmer::with_read(no_composer).confirm("reviewer", RULE),
+            Delivery::Unconfirmed("no composer found in the pane".into())
+        );
     }
 }

--- a/src/herd.rs
+++ b/src/herd.rs
@@ -50,9 +50,8 @@ const FINGERPRINT_CHARS: usize = 40;
 /// landed between the write and the snapshot.
 const REREAD_DELAY: std::time::Duration = std::time::Duration::from_millis(400);
 
-/// Consecutive horizontal box-drawing characters that make a line a rule.
-/// Long enough that prose quoting a rule (`"\u{2500}\u{2500}\u{2500} Context \u{2500}\u{2500}\u{2500}"`) is not
-/// mistaken for one.
+/// Horizontal box-drawing characters a line needs before it counts as a
+/// rule, so that a lone `\u{2502}` or a two-character fragment is not one.
 const RULE_RUN: usize = 8;
 
 /// Whitespace-insensitive form. The composer wraps at word boundaries and
@@ -61,53 +60,76 @@ fn normalize(s: &str) -> String {
     s.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
-/// Least composer text that can be taken for a run of our own. A rule inside
-/// a message body splits the composer region, leaving only the text below it
-/// to match; this is the floor at which that remainder is ours rather than a
-/// short phrase someone happened to type.
-const SPLIT_TAIL_CHARS: usize = 16;
-
-/// Whether `region` is the tail of a composer whose top a rule inside the
-/// message body cut off.
-fn is_split_tail(region: &str, sent: &str) -> bool {
-    region.chars().count() >= SPLIT_TAIL_CHARS && sent.contains(region)
+/// The composer's prompt marker is furniture, not content. Stripping it is
+/// what separates a cleared composer from one holding text, and it stops a
+/// batch that happens to quote a marker from making a cleared composer look
+/// occupied.
+fn strip_marker(region: &str) -> &str {
+    let is_marker = |t: &str| t.chars().count() == 1 && !t.chars().any(char::is_alphanumeric);
+    match region.split_once(' ') {
+        Some((first, rest)) if is_marker(first) => rest,
+        _ if is_marker(region) => "",
+        _ => region,
+    }
 }
 
-/// A horizontal rule, which is how the composer box is drawn. Any of the
-/// box-drawing horizontals — heavy, double, dashed — counts, since which one
-/// a terminal UI picks is its own business; a run of them is required so that
-/// text merely containing one is content, not furniture.
+/// Whether a line *is* a horizontal rule, which is how the composer box is
+/// drawn. Any of the box-drawing horizontals counts — heavy, double, dashed,
+/// block — since which one a terminal UI picks is its own business, and
+/// corners and verticals may bracket the run.
+///
+/// The whole line has to be rule characters. A line that merely contains a
+/// run is content: a message body carrying box-drawn terminal output reaches
+/// the composer with its line breaks intact, and treating one of its lines as
+/// furniture would move the composer boundary onto it.
 fn is_rule(line: &str) -> bool {
-    let mut run = 0;
+    let line = line.trim();
+    let mut horizontals = 0;
     for c in line.chars() {
-        run = match c {
+        match c {
             // light, heavy, dashed and double horizontals; the horizontal
             // bar and extension; the block halves a UI may rule with
             '\u{2500}' | '\u{2501}' | '\u{2504}' | '\u{2505}' | '\u{2508}' | '\u{2509}'
             | '\u{254c}' | '\u{254d}' | '\u{2550}' | '\u{2015}' | '\u{23af}' | '\u{2580}'
-            | '\u{2581}' | '\u{2584}' | '\u{2594}' => run + 1,
-            _ => 0,
-        };
-        if run >= RULE_RUN {
-            return true;
+            | '\u{2581}' | '\u{2584}' | '\u{2594}' => horizontals += 1,
+            // corners, tees and verticals may bracket or join the run
+            '\u{2502}'
+            | '\u{2503}'
+            | '\u{2506}'
+            | '\u{2507}'
+            | '\u{250a}'
+            | '\u{250b}'
+            | '\u{250c}'..='\u{254b}'
+            | '\u{254e}'
+            | '\u{254f}'
+            | '\u{2551}'..='\u{256c}' => {}
+            _ => return false,
         }
     }
-    false
+    horizontals >= RULE_RUN
 }
 
 /// Whether `sent` is sitting unsubmitted on `pane`'s composer — the region
 /// between the last two horizontal rules, below which there is only the
-/// status footer. It counts as ours when it opens with our fingerprint, or
-/// when a rule inside a message body cut the top off and only a run of our
-/// own text is left (`is_split_tail`).
+/// status footer.
 ///
-/// `None` means no composer could be located. That is ambiguous rather than
-/// informative: it happens when an unsubmitted batch is tall enough to push
-/// its own top rule off the screen, when a pane draws no composer at all,
-/// and when a rule is drawn some way this does not recognize. The ambiguity
-/// is resolved toward "not submitted" by the caller, because a wrong
-/// `Submitted` drops the batch permanently while a wrong `Unconfirmed` costs
-/// a repeat delivery and converges on the skip threshold.
+/// Three answers, and the boundary between them is where this earns its
+/// keep. Text that is a run of our own — whole, or with its top cut off by a
+/// rule inside a message body — is `Some(true)`. `Some(false)` is claimed
+/// only for a composer that was found and then either cleared or holding
+/// text that is not ours; someone typing at the pane does not make our
+/// delivery undelivered, which is #24's question and stays out of scope.
+/// Everything else is `None`: no rules to bound a region, or a region with
+/// nothing in it at all, which means the pair of rules found was not the
+/// composer's.
+///
+/// `None` is ambiguous rather than informative — it covers an unsubmitted
+/// batch tall enough to push its own top rule off screen, a pane drawing no
+/// composer, and a rule drawn some way `is_rule` does not know — so the
+/// caller resolves it toward "not submitted". A wrong `Submitted` drops the
+/// batch permanently; a wrong `Unconfirmed` costs a repeat delivery and
+/// converges on the skip threshold. Every path here that cannot tell must
+/// therefore reach `None` rather than falling through to `Some(false)`.
 fn composer_holds(pane: &str, sent: &str) -> Option<bool> {
     let lines: Vec<&str> = pane.lines().collect();
     let rules: Vec<usize> = lines
@@ -120,9 +142,21 @@ fn composer_holds(pane: &str, sent: &str) -> Option<bool> {
         return None;
     };
     let region = normalize(&lines[top + 1..bottom].join(" "));
+    if region.is_empty() {
+        // Not even a prompt marker: a composer always draws one, so these
+        // two rules bound something else — most often a message body that
+        // ended with a rule of its own.
+        return None;
+    }
+    let content = strip_marker(&region);
+    if content.is_empty() {
+        return Some(false);
+    }
     let sent = normalize(sent);
     let fingerprint: String = sent.chars().take(FINGERPRINT_CHARS).collect();
-    Some(region.contains(&fingerprint) || is_split_tail(&region, &sent))
+    // Either the composer opens with our text, or a rule inside a message
+    // body cut its top off and what is left is still a run of our own.
+    Some(content.contains(&fingerprint) || sent.contains(content))
 }
 
 fn read_pane(name: &str) -> Result<String> {
@@ -487,20 +521,73 @@ mod tests {
             let r = c.to_string().repeat(RULE_RUN);
             assert!(is_rule(&r), "{c:?} run not recognized");
         }
-        // a rule with corners, and a titled rule, both still read as rules
+        // corners may bracket the run, and surrounding whitespace is ignored
         assert!(is_rule(&format!(
-            "\u{250c}{}\u{2510}",
+            "  \u{250c}{}\u{2510}  ",
             "\u{2500}".repeat(20)
         )));
-        assert!(is_rule(&format!(
+        // a fragment is not a rule
+        assert!(!is_rule("\u{2500}\u{2500}"));
+        assert!(!is_rule(""));
+    }
+
+    #[test]
+    fn a_line_merely_containing_a_run_is_content_not_furniture() {
+        // The whole-line property is what keeps a message body out of the
+        // composer boundary. A titled rule is prose by the same test.
+        assert!(!is_rule(
+            "like \"\u{2500}\u{2500}\u{2500} Context \u{2500}\u{2500}\u{2500}\", dashed variants"
+        ));
+        assert!(!is_rule(&format!(
             "{} Context {}",
             "\u{2500}".repeat(10),
             "\u{2500}".repeat(10)
         )));
-        // and a short run in prose is not
-        assert!(!is_rule(
-            "like \"\u{2500}\u{2500}\u{2500} Context \u{2500}\u{2500}\u{2500}\", dashed variants"
-        ));
+        assert!(!is_rule("[#1] someone: load \u{2581}\u{2581}\u{2581}\u{2581}\u{2581}\u{2584}\u{2584}\u{2584} ok"));
+    }
+
+    #[test]
+    fn a_run_inside_a_message_body_does_not_relocate_the_boundary() {
+        // Message bodies keep their line breaks through `scrub`, so a pasted
+        // line of block-drawn output lands in the composer as its own line.
+        // Reading it as furniture put the boundary on it, emptied the region
+        // and reported the batch submitted — silent loss.
+        let composer = [
+            "\u{276f} Reply only if you have information others don't \u{2014} don't",
+            "  acknowledge or repeat. Under 80 words; longer belongs on the issue.",
+            "  [scuttlebutt] New messages in the room:",
+            "  [#1] someone: load \u{2581}\u{2581}\u{2581}\u{2581}\u{2581}\u{2584}\u{2584}\u{2584} ok",
+        ];
+        assert_eq!(composer_holds(&pane(&composer), RULE), Some(true));
+    }
+
+    #[test]
+    fn a_batch_ending_in_a_rule_is_not_read_as_a_cleared_composer() {
+        // The message's own rule becomes the top of the last pair, leaving
+        // an empty region. Nothing was found, so nothing is confirmed.
+        let composer = [
+            "\u{276f} Reply only if you have information others don't \u{2014} don't",
+            "  [scuttlebutt] New messages in the room:",
+            &"\u{2500}".repeat(30),
+        ];
+        assert_eq!(composer_holds(&pane(&composer), RULE), None);
+    }
+
+    #[test]
+    fn a_short_tail_below_a_body_rule_is_still_ours() {
+        // The remainder can be shorter than any fingerprint. Requiring a
+        // minimum length here reported the batch submitted and dropped it.
+        let sent = format!(
+            "{RULE}\n[scuttlebutt] New messages in the room:\n[#1] a: {}\nthanks all",
+            "\u{2500}".repeat(30)
+        );
+        let composer = [
+            "\u{276f} Reply only if you have information others don't",
+            "  [#1] a:",
+            &"\u{2500}".repeat(30),
+            "  thanks all",
+        ];
+        assert_eq!(composer_holds(&pane(&composer), &sent), Some(true));
     }
 
     #[test]
@@ -519,20 +606,30 @@ mod tests {
         assert_eq!(composer_holds(&pane(&composer), &sent), Some(true));
     }
 
-    fn ok_pane(_: &str) -> Result<String> {
-        Ok(EMPTY.to_string())
-    }
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
-    fn unreadable(_: &str) -> Result<String> {
-        anyhow::bail!("agent target gone not found")
-    }
+    /// One counter per test rather than one shared by all of them: a static
+    /// that several tests reset races under `cargo test`'s parallelism, which
+    /// is what #30 is about.
+    static CLEARED_READS: AtomicUsize = AtomicUsize::new(0);
+    static REPAINT_READS: AtomicUsize = AtomicUsize::new(0);
+    static STUCK_READS: AtomicUsize = AtomicUsize::new(0);
 
     #[test]
-    fn a_confirmed_first_look_costs_no_retry() {
+    fn a_confirmed_first_look_costs_one_read_and_no_retry() {
+        // The retry costs a `REREAD_DELAY` on every delivery if it is not
+        // skipped on the happy path, so the read count is the assertion —
+        // `Submitted` alone would hold however many looks it took.
+        fn cleared(_: &str) -> Result<String> {
+            CLEARED_READS.fetch_add(1, Ordering::SeqCst);
+            Ok(EMPTY.to_string())
+        }
+        CLEARED_READS.store(0, Ordering::SeqCst);
         assert_eq!(
-            Confirmer::with_read(ok_pane).confirm("reviewer", RULE),
+            Confirmer::with_read(cleared).confirm("reviewer", RULE),
             Delivery::Submitted
         );
+        assert_eq!(CLEARED_READS.load(Ordering::SeqCst), 1);
     }
 
     #[test]
@@ -541,34 +638,41 @@ mod tests {
         // the pane has not repainted yet. Retrying is what keeps a healthy
         // delivery from being reported as undelivered.
         fn repainting(_: &str) -> Result<String> {
-            use std::sync::atomic::{AtomicUsize, Ordering};
-            static LOOKS: AtomicUsize = AtomicUsize::new(0);
-            Ok(match LOOKS.fetch_add(1, Ordering::SeqCst) {
+            Ok(match REPAINT_READS.fetch_add(1, Ordering::SeqCst) {
                 0 => HOLDS_BATCH.to_string(),
                 _ => EMPTY.to_string(),
             })
         }
+        REPAINT_READS.store(0, Ordering::SeqCst);
         assert_eq!(
             Confirmer::with_read(repainting).confirm("reviewer", RULE),
             Delivery::Submitted
         );
+        assert_eq!(REPAINT_READS.load(Ordering::SeqCst), 2);
     }
 
     #[test]
     fn text_still_on_the_composer_after_both_looks_is_unconfirmed() {
         fn stuck(_: &str) -> Result<String> {
+            STUCK_READS.fetch_add(1, Ordering::SeqCst);
             Ok(HOLDS_BATCH.to_string())
         }
+        STUCK_READS.store(0, Ordering::SeqCst);
         assert_eq!(
             Confirmer::with_read(stuck).confirm("reviewer", RULE),
             Delivery::Unconfirmed("the text is still on the composer".into())
         );
+        // two looks and no more: the wait is paid once, not per tick
+        assert_eq!(STUCK_READS.load(Ordering::SeqCst), 2);
     }
 
     #[test]
     fn an_unreadable_pane_is_unconfirmed_and_names_the_cause() {
         // The agent's pane closed between the prompt and the read: nothing
         // was delivered, and the operator needs to see why.
+        fn unreadable(_: &str) -> Result<String> {
+            anyhow::bail!("agent target gone not found")
+        }
         let Delivery::Unconfirmed(why) = Confirmer::with_read(unreadable).confirm("gone", RULE)
         else {
             panic!("an unreadable pane confirmed a delivery");

--- a/src/herd.rs
+++ b/src/herd.rs
@@ -602,6 +602,18 @@ mod tests {
     }
 
     #[test]
+    fn a_composer_clipped_mid_word_still_matches() {
+        // Clipping does not always leave an ellipsis to cut, so the last
+        // word can arrive truncated. It matches because a window is compared
+        // as a substring rather than as whole tokens, and a truncated final
+        // word is a prefix of the real one. Pinned because switching that
+        // comparison to word boundaries would reopen a fall-through: three
+        // words, all of them ours, matching nothing, reported submitted.
+        let composer = ["\u{276f} Reply only i".to_string()];
+        assert_eq!(holds(&composer, RULE), Some(true));
+    }
+
+    #[test]
     fn someone_elses_text_on_the_composer_confirms_submission() {
         // A human typing at the pane did not stop our delivery landing, and
         // telling their text from a tool's is #24, which stays out of scope.

--- a/src/herd.rs
+++ b/src/herd.rs
@@ -28,22 +28,17 @@ pub trait HerdControl {
     fn prompt(&self, name: &str, text: &str) -> Result<Delivery>;
 }
 
-/// Characters of the sent text matched against the composer.
-///
-/// Deliberately *not* unique to one batch: every batch opens with the same
-/// `DELIVERY_RULE`, so this identifies scuttlebutt's outgoing text in
-/// general, not this particular send. That is sound only because `herdr
-/// agent prompt` replaces the composer contents rather than appending to
-/// them — observed on live panes and recorded on #26 — so text matching the
-/// fingerprint after a prompt can only be the text that prompt just wrote.
-///
-/// If herdr ever appends instead, an older batch left unsent on the composer
-/// would make a genuinely submitted new batch read as unsubmitted. That
-/// costs a repeat delivery and converges on the skip threshold; it does not
-/// lose a batch silently, which is the failure this whole path exists to
-/// prevent. No unit test can guard a third-party invariant, so it is named
-/// here instead.
-const FINGERPRINT_CHARS: usize = 40;
+/// Prompt markers a composer opens with. Identification is by this set
+/// rather than "any punctuation": a marker we do not know is a composer we
+/// have not identified, which resolves to `Unconfirmed` and costs a repeat.
+/// Guessing instead resolves to `Submitted` and costs the batch.
+const MARKERS: [&str; 3] = ["\u{276f}", ">", "\u{203a}"];
+
+/// Words of the composer that must reappear, in order, in what we sent
+/// before the composer counts as holding our text. Three rather than a
+/// character-count fingerprint because the composer clips, wraps mid-token
+/// and pads with NBSP — all of which survive a short run of whole words.
+const OVERLAP_WORDS: usize = 3;
 
 /// How long to let the pane repaint before a second look. Paid only when the
 /// first look failed to confirm, which on a healthy pane means the prompt
@@ -60,28 +55,15 @@ fn normalize(s: &str) -> String {
     s.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
-/// The composer's prompt marker is furniture, not content. Stripping it is
-/// what separates a cleared composer from one holding text, and it stops a
-/// batch that happens to quote a marker from making a cleared composer look
-/// occupied.
-fn strip_marker(region: &str) -> &str {
-    let is_marker = |t: &str| t.chars().count() == 1 && !t.chars().any(char::is_alphanumeric);
-    match region.split_once(' ') {
-        Some((first, rest)) if is_marker(first) => rest,
-        _ if is_marker(region) => "",
-        _ => region,
-    }
-}
-
-/// Whether a line *is* a horizontal rule, which is how the composer box is
+/// Whether a line *is* a horizontal rule, which is how a composer box is
 /// drawn. Any of the box-drawing horizontals counts — heavy, double, dashed,
 /// block — since which one a terminal UI picks is its own business, and
-/// corners and verticals may bracket the run.
+/// corners (square or rounded), tees and verticals may bracket the run.
 ///
 /// The whole line has to be rule characters. A line that merely contains a
 /// run is content: a message body carrying box-drawn terminal output reaches
 /// the composer with its line breaks intact, and treating one of its lines as
-/// furniture would move the composer boundary onto it.
+/// furniture would move a region boundary onto it.
 fn is_rule(line: &str) -> bool {
     let line = line.trim();
     let mut horizontals = 0;
@@ -92,7 +74,7 @@ fn is_rule(line: &str) -> bool {
             '\u{2500}' | '\u{2501}' | '\u{2504}' | '\u{2505}' | '\u{2508}' | '\u{2509}'
             | '\u{254c}' | '\u{254d}' | '\u{2550}' | '\u{2015}' | '\u{23af}' | '\u{2580}'
             | '\u{2581}' | '\u{2584}' | '\u{2594}' => horizontals += 1,
-            // corners, tees and verticals may bracket or join the run
+            // corners, tees, verticals and half-lines may bracket or join it
             '\u{2502}'
             | '\u{2503}'
             | '\u{2506}'
@@ -102,35 +84,24 @@ fn is_rule(line: &str) -> bool {
             | '\u{250c}'..='\u{254b}'
             | '\u{254e}'
             | '\u{254f}'
-            | '\u{2551}'..='\u{256c}' => {}
+            | '\u{2551}'..='\u{257f}' => {}
             _ => return false,
         }
     }
     horizontals >= RULE_RUN
 }
 
-/// Whether `sent` is sitting unsubmitted on `pane`'s composer — the region
-/// between the last two horizontal rules, below which there is only the
-/// status footer.
+/// The content of every rule-bounded region in `pane` that opens with a
+/// prompt marker, marker stripped and whitespace normalized.
 ///
-/// Three answers, and the boundary between them is where this earns its
-/// keep. Text that is a run of our own — whole, or with its top cut off by a
-/// rule inside a message body — is `Some(true)`. `Some(false)` is claimed
-/// only for a composer that was found and then either cleared or holding
-/// text that is not ours; someone typing at the pane does not make our
-/// delivery undelivered, which is #24's question and stays out of scope.
-/// Everything else is `None`: no rules to bound a region, or a region with
-/// nothing in it at all, which means the pair of rules found was not the
-/// composer's.
-///
-/// `None` is ambiguous rather than informative — it covers an unsubmitted
-/// batch tall enough to push its own top rule off screen, a pane drawing no
-/// composer, and a rule drawn some way `is_rule` does not know — so the
-/// caller resolves it toward "not submitted". A wrong `Submitted` drops the
-/// batch permanently; a wrong `Unconfirmed` costs a repeat delivery and
-/// converges on the skip threshold. Every path here that cannot tell must
-/// therefore reach `None` rather than falling through to `Some(false)`.
-fn composer_holds(pane: &str, sent: &str) -> Option<bool> {
+/// Every such region is returned, not just the last one, and that is the
+/// point. A message body ending in a rule of its own, or a bordered box
+/// drawn below the composer, both put a *different* region last; picking one
+/// region by position is a guess, and a wrong guess here reports a batch
+/// submitted that is sitting on a composer two lines up. A transcript echo
+/// of a submitted prompt cannot be mistaken for one of these, because the
+/// transcript draws no rules around it.
+fn composer_regions(pane: &str) -> Vec<String> {
     let lines: Vec<&str> = pane.lines().collect();
     let rules: Vec<usize> = lines
         .iter()
@@ -138,25 +109,75 @@ fn composer_holds(pane: &str, sent: &str) -> Option<bool> {
         .filter(|(_, l)| is_rule(l))
         .map(|(i, _)| i)
         .collect();
-    let [.., top, bottom] = rules[..] else {
+    rules
+        .windows(2)
+        .filter_map(|w| {
+            let region = normalize(&lines[w[0] + 1..w[1]].join(" "));
+            let marker = MARKERS.iter().find(|m| region.starts_with(**m))?;
+            Some(region[marker.len()..].trim().to_string())
+        })
+        .collect()
+}
+
+/// Whether `content` is a run of `sent` rather than something else on the
+/// composer. Matched as whole words in order, so a composer that wrapped the
+/// text mid-token or padded it with NBSP still matches: a mangled word kills
+/// only the windows it appears in, and any longer run has clean ones.
+///
+/// The clip marker is cut first, because it fuses onto the last word and
+/// there is no window after it to fall back on — `\u{276f} Reply only if\u{2026}` is
+/// three words, all of them ours, and none of them matching with the
+/// ellipsis still attached. Clipped shorter than that, the content is too
+/// short to classify and never reaches a confirmation at all.
+fn is_our_text(content: &str, sent: &str) -> bool {
+    let content = content
+        .trim_end_matches(['\u{2026}', '.', ' '])
+        .trim_start_matches(['\u{2026}', '.', ' ']);
+    let words: Vec<&str> = content.split_whitespace().collect();
+    words
+        .windows(OVERLAP_WORDS)
+        .any(|w| sent.contains(&w.join(" ")))
+}
+
+/// Whether `sent` is sitting unsubmitted on `pane`'s composer.
+///
+/// `Some(false)` — submitted — is the only answer that advances a cursor and
+/// so the only one that can lose a batch, and it is reachable on exactly one
+/// path: at least one composer was identified, and every identified composer
+/// is either empty or holds text long enough to be recognized as not ours.
+/// Everything else is `None`, including cases that look like nothing at all:
+/// no rules, no marker, a marker we do not know, or content too short to
+/// classify either way.
+///
+/// The caller resolves `None` toward "not submitted". A wrong `Submitted`
+/// drops the batch permanently; a wrong `Unconfirmed` costs a repeat
+/// delivery, bounded by the unconfirmed streak. This shape is deliberate:
+/// three review rounds found layouts nobody anticipated, and each one was a
+/// case that failed to match and fell through to `Submitted`. There is no
+/// fall-through here — a layout this does not understand cannot reach it.
+fn composer_holds(pane: &str, sent: &str) -> Option<bool> {
+    let regions = composer_regions(pane);
+    if regions.is_empty() {
         return None;
-    };
-    let region = normalize(&lines[top + 1..bottom].join(" "));
-    if region.is_empty() {
-        // Not even a prompt marker: a composer always draws one, so these
-        // two rules bound something else — most often a message body that
-        // ended with a rule of its own.
-        return None;
-    }
-    let content = strip_marker(&region);
-    if content.is_empty() {
-        return Some(false);
     }
     let sent = normalize(sent);
-    let fingerprint: String = sent.chars().take(FINGERPRINT_CHARS).collect();
-    // Either the composer opens with our text, or a rule inside a message
-    // body cut its top off and what is left is still a run of our own.
-    Some(content.contains(&fingerprint) || sent.contains(content))
+    if regions.iter().any(|c| is_our_text(c, &sent)) {
+        return Some(true);
+    }
+    // Non-empty but too short to tell ours from a placeholder or a menu.
+    // Idle composers really do carry text that is neither: `\u{276f} Press up to
+    // edit queued messages` is what Claude Code shows over a queue.
+    let classifiable = |c: &String| {
+        let words = c
+            .trim_end_matches(['\u{2026}', '.', ' '])
+            .split_whitespace()
+            .count();
+        words == 0 || words >= OVERLAP_WORDS
+    };
+    match regions.iter().all(classifiable) {
+        true => Some(false),
+        false => None,
+    }
 }
 
 fn read_pane(name: &str) -> Result<String> {
@@ -221,7 +242,7 @@ impl Confirmer {
             Ok(pane) => match composer_holds(&pane, sent) {
                 Some(false) => Delivery::Submitted,
                 Some(true) => Delivery::Unconfirmed("the text is still on the composer".into()),
-                None => Delivery::Unconfirmed("no composer found in the pane".into()),
+                None => Delivery::Unconfirmed("no composer could be identified in the pane".into()),
             },
         }
     }
@@ -395,6 +416,19 @@ mod tests {
     const RULE: &str =
         "Reply only if you have information others don't \u{2014} don't acknowledge or repeat.";
 
+    /// Captured verbatim from `herdr agent read --source visible --format
+    /// text` on live Claude Code panes, transcript above the composer
+    /// trimmed. `composer-holds-batch` was taken with a real delivery
+    /// preamble typed into the composer and never submitted — the #26 state;
+    /// `composer-empty` is the same pane cleared; `composer-placeholder` is
+    /// a different pane showing the hint Claude Code puts on an idle
+    /// composer over a queue, which is text that is neither ours nor a
+    /// human's. `composer-holds-batch` and `composer-empty` keep one
+    /// transcript line quoting box-drawing characters.
+    const HOLDS_BATCH: &str = include_str!("../tests/fixtures/composer-holds-batch.txt");
+    const EMPTY: &str = include_str!("../tests/fixtures/composer-empty.txt");
+    const PLACEHOLDER: &str = include_str!("../tests/fixtures/composer-placeholder.txt");
+
     /// A pane rendered the way herdr's `visible` snapshot returns it: a
     /// transcript, the composer box, then the status footer.
     fn pane(composer: &[&str]) -> String {
@@ -413,83 +447,25 @@ mod tests {
         out.join("\n")
     }
 
-    #[test]
-    fn an_empty_composer_confirms_submission() {
-        assert_eq!(composer_holds(&pane(&["\u{276f}"]), RULE), Some(false));
-    }
-
-    #[test]
-    fn our_own_text_on_the_composer_is_not_submitted() {
-        // The #26 pane: herdr returned success, the batch is sitting unsent.
-        let composer = [
-            "\u{276f} Reply only if you have information others don't \u{2014} don't",
-            "  acknowledge or repeat. Under 80 words; longer belongs on the issue.",
-            "  [scuttlebutt] New messages in the room:",
+    /// The batch as it renders on a composer: wrapped, NBSP-padded, and
+    /// followed by whatever the caller wants after it.
+    fn held(extra: &[&str]) -> Vec<String> {
+        let mut lines = vec![
+            "\u{276f}\u{a0}Reply only if you have information others don't \u{2014} don't"
+                .to_string(),
+            "  acknowledge or repeat. Under 80 words; longer belongs on the issue.".to_string(),
+            "  [scuttlebutt] New messages in the room:".to_string(),
         ];
-        assert_eq!(composer_holds(&pane(&composer), RULE), Some(true));
+        lines.extend(extra.iter().map(|l| l.to_string()));
+        lines
     }
 
-    #[test]
-    fn someone_elses_text_on_the_composer_confirms_submission() {
-        // A human typing at the pane is not our text: the delivery still
-        // went through, and #24 stays out of scope.
-        let composer = ["\u{276f} stop posting to the room and stand down"];
-        assert_eq!(composer_holds(&pane(&composer), RULE), Some(false));
+    fn holds(composer: &[String], sent: &str) -> Option<bool> {
+        let refs: Vec<&str> = composer.iter().map(String::as_str).collect();
+        composer_holds(&pane(&refs), sent)
     }
 
-    #[test]
-    fn the_same_text_in_the_transcript_confirms_submission() {
-        // Submitted text is echoed above the composer. Only the composer
-        // region is consulted, or every delivery would look undelivered.
-        let echoed = format!("\u{276f} {RULE}\n{}", pane(&["\u{276f}"]));
-        assert_eq!(composer_holds(&echoed, RULE), Some(false));
-    }
-
-    #[test]
-    fn a_wrapped_composer_still_matches() {
-        // The composer wraps at word boundaries and pads with NBSP; matching
-        // has to see through both.
-        let composer = [
-            "\u{276f}\u{a0}Reply  only if you",
-            "  have information others don't \u{2014} don't acknowledge or repeat.",
-        ];
-        assert_eq!(composer_holds(&pane(&composer), RULE), Some(true));
-    }
-
-    #[test]
-    fn a_composer_that_cannot_be_located_is_not_confirmed() {
-        // A batch tall enough to push its own top rule off screen. A
-        // submitted prompt always leaves both rules on screen, so an
-        // unlocatable composer is evidence against submission, not for it.
-        let clipped = format!(
-            "  {RULE}\n  [scuttlebutt] New messages in the room:\n{}\n  status",
-            "\u{2500}".repeat(60)
-        );
-        assert_eq!(composer_holds(&clipped, RULE), None);
-        assert_eq!(composer_holds("", RULE), None);
-    }
-
-    #[test]
-    fn ascii_rules_in_a_message_are_content_not_furniture() {
-        // A post containing `-----` reaches the pane unaltered; reading it as
-        // a composer edge would move the region and hide the real text.
-        let composer = [
-            "\u{276f} Reply only if you have information others don't \u{2014} don't",
-            "  -------------------------",
-            "  acknowledge or repeat.",
-        ];
-        assert_eq!(composer_holds(&pane(&composer), RULE), Some(true));
-    }
-
-    /// Captured verbatim from `herdr agent read --source visible --format
-    /// text` on a live Claude Code pane, transcript above the composer
-    /// trimmed. `composer-holds-batch` was taken with a real delivery
-    /// preamble typed into the composer and never submitted — the #26 state;
-    /// `composer-empty` is the same pane with the composer cleared. Both
-    /// keep one transcript line quoting box-drawing characters, which is
-    /// what stops `is_rule` from being loosened into matching prose.
-    const HOLDS_BATCH: &str = include_str!("../tests/fixtures/composer-holds-batch.txt");
-    const EMPTY: &str = include_str!("../tests/fixtures/composer-empty.txt");
+    // ---- the real panes -------------------------------------------------
 
     #[test]
     fn a_real_pane_holding_an_unsubmitted_batch_is_not_confirmed() {
@@ -502,15 +478,191 @@ mod tests {
     }
 
     #[test]
+    fn a_real_placeholder_composer_confirms_submission() {
+        // `\u{276f} Press up to edit queued messages` is the hint Claude Code shows
+        // over a queue. Requiring an empty composer would leave every agent
+        // in that state permanently unconfirmable, and the streak would then
+        // skip real batches.
+        assert_eq!(composer_holds(PLACEHOLDER, RULE), Some(false));
+    }
+
+    #[test]
     fn a_real_transcript_line_quoting_a_rule_is_not_a_rule() {
-        // Both fixtures carry a line containing `\u{2500}\u{2500}\u{2500} Context \u{2500}\u{2500}\u{2500}`. Treating it
-        // as furniture would move the composer region up into the transcript.
         let quoting: Vec<&str> = HOLDS_BATCH
             .lines()
             .filter(|l| l.contains('\u{2500}') && !is_rule(l))
             .collect();
         assert!(!quoting.is_empty(), "fixture lost its rule-quoting line");
         assert_eq!(composer_holds(HOLDS_BATCH, RULE), Some(true));
+    }
+
+    // ---- nothing identified is never a confirmation ---------------------
+
+    #[test]
+    fn a_pane_with_no_rules_identifies_no_composer() {
+        assert_eq!(composer_holds("a plain shell\n$ ", RULE), None);
+        assert_eq!(composer_holds("", RULE), None);
+    }
+
+    #[test]
+    fn a_region_without_a_known_marker_identifies_no_composer() {
+        // A bordered box that is not a composer — a notification band, a
+        // permission prompt — must not be read as one and reported clear.
+        let composer = ["  Allow this command? [y/N]"];
+        assert_eq!(holds(&composer.map(String::from), RULE), None);
+    }
+
+    #[test]
+    fn an_unrecognized_marker_identifies_no_composer() {
+        let composer = ["\u{2794} Reply only if you have information others don't"];
+        assert_eq!(holds(&composer.map(String::from), RULE), None);
+    }
+
+    #[test]
+    fn content_too_short_to_classify_is_not_a_confirmation() {
+        // One or two words could be a placeholder, a menu row, or the last
+        // clipped fragment of our own batch. Unclassifiable is not clear.
+        for short in ["-", "\u{1f389}", "ok", "5"] {
+            let composer = [format!("\u{276f} {short}")];
+            assert_eq!(holds(&composer, RULE), None, "{short:?} was classified");
+        }
+    }
+
+    // ---- the boundary cannot be relocated -------------------------------
+
+    #[test]
+    fn a_run_inside_a_message_body_does_not_relocate_the_boundary() {
+        // Message bodies keep their line breaks through `scrub`, so a pasted
+        // line of block-drawn output lands in the composer as its own line.
+        let composer = held(&["  [#1] someone: load \u{2581}\u{2581}\u{2581}\u{2581}\u{2581}\u{2584}\u{2584}\u{2584} ok"]);
+        assert_eq!(holds(&composer, RULE), Some(true));
+    }
+
+    #[test]
+    fn a_batch_ending_in_a_rule_is_still_found() {
+        // The message's own rule splits the composer in two. The half that
+        // opens with the marker is still a composer and still holds us.
+        let composer = held(&[&"\u{2500}".repeat(30)]);
+        assert_eq!(holds(&composer, RULE), Some(true));
+    }
+
+    #[test]
+    fn a_one_character_tail_below_a_body_rule_is_not_a_confirmation() {
+        // The tail region has no marker, so it is not a composer at all; the
+        // half above it is, and it holds the batch.
+        let composer = held(&[&"\u{2500}".repeat(30), "  -"]);
+        assert_eq!(holds(&composer, RULE), Some(true));
+    }
+
+    #[test]
+    fn a_box_below_the_composer_does_not_hide_the_batch() {
+        // A permission prompt or notification band drawn under the composer
+        // puts a different region last. Every marker-led region is checked,
+        // so the batch two lines up is still found.
+        let mut composer = held(&[]);
+        composer.push("\u{2500}".repeat(60));
+        composer.push("\u{276f} 1. Yes, allow this command to run".into());
+        assert_eq!(holds(&composer, RULE), Some(true));
+    }
+
+    #[test]
+    fn a_rounded_composer_box_is_still_a_composer() {
+        // Synthetic: no pane here draws one, but a UI that did would
+        // otherwise identify nothing on every tick.
+        let rounded = format!("\u{256d}{}\u{256e}", "\u{2500}".repeat(40));
+        let pane = format!("\u{25cf} done\n{rounded}\n\u{276f}\n{rounded}\n  status line");
+        assert_eq!(composer_holds(&pane, RULE), Some(false));
+    }
+
+    // ---- matching what is there -----------------------------------------
+
+    #[test]
+    fn a_wrapped_and_nbsp_padded_composer_still_matches() {
+        assert_eq!(holds(&held(&[]), RULE), Some(true));
+    }
+
+    #[test]
+    fn a_hard_wrapped_token_still_matches() {
+        // A narrow pane breaks mid-token, so normalize sees two words where
+        // we sent one. Whole-word runs elsewhere in the batch still match.
+        let sent = format!("{RULE} see https://example.com/a/very/long/path for the rest");
+        let composer = [
+            "\u{276f} Reply only if you have information others don't \u{2014} don't".to_string(),
+            "  acknowledge or repeat. see https://example.com/a/very/lo".to_string(),
+            "  ng/path for the rest".to_string(),
+        ];
+        assert_eq!(holds(&composer, &sent), Some(true));
+    }
+
+    #[test]
+    fn a_clipped_composer_still_matches() {
+        // Claude Code clips a tall composer; three words of ours is enough.
+        let composer = ["\u{276f} Reply only if\u{2026}".to_string()];
+        assert_eq!(holds(&composer, RULE), Some(true));
+    }
+
+    #[test]
+    fn someone_elses_text_on_the_composer_confirms_submission() {
+        // A human typing at the pane did not stop our delivery landing, and
+        // telling their text from a tool's is #24, which stays out of scope.
+        let composer = ["\u{276f} stop posting to the room and stand down".to_string()];
+        assert_eq!(holds(&composer, RULE), Some(false));
+    }
+
+    #[test]
+    fn the_same_text_in_the_transcript_confirms_submission() {
+        // Submitted text is echoed above the composer, with no rules drawn
+        // around it, so it forms no region and cannot be mistaken for one.
+        let echoed = format!("\u{276f} {RULE}\n{}", EMPTY);
+        assert_eq!(composer_holds(&echoed, RULE), Some(false));
+    }
+
+    #[test]
+    fn no_layout_change_turns_a_held_batch_into_a_confirmation() {
+        // The property, stated directly. Three review rounds each found a
+        // layout that made a held batch read as submitted, and each was a
+        // different input rather than a different bug. Any perturbation may
+        // cost identification — `None`, a repeat delivery — but none of them
+        // may reach `Some(false)`, which advances the cursor and drops it.
+        let rounded = format!("\u{256d}{}\u{256e}", "\u{2500}".repeat(60));
+        let held = held(&[]).join("\n");
+        let perturbed = [
+            // a bordered box drawn below the composer
+            format!(
+                "{HOLDS_BATCH}\n{}\n\u{276f} 1. Yes\n{}",
+                "\u{2500}".repeat(60),
+                "\u{2500}".repeat(60)
+            ),
+            // the composer's own box drawn with rounded corners
+            format!("\u{25cf} done\n{rounded}\n{held}\n{rounded}\n  status"),
+            // a rule inside a message body, with tails of several lengths
+            format!(
+                "{}\n{held}\n{}\n  -\n{}",
+                "\u{2500}".repeat(60),
+                "\u{2500}".repeat(60),
+                "\u{2500}".repeat(60)
+            ),
+            format!(
+                "{}\n{held}\n{}\n  thanks all\n{}",
+                "\u{2500}".repeat(60),
+                "\u{2500}".repeat(60),
+                "\u{2500}".repeat(60)
+            ),
+            // the top rule scrolled off a narrow screen
+            HOLDS_BATCH.lines().skip(5).collect::<Vec<_>>().join("\n"),
+            // an unfamiliar marker, and none at all
+            HOLDS_BATCH.replace('\u{276f}', "\u{2794}"),
+            HOLDS_BATCH.replace('\u{276f}', " "),
+            // no furniture whatsoever
+            held.clone(),
+        ];
+        for (i, pane) in perturbed.iter().enumerate() {
+            assert_ne!(
+                composer_holds(pane, RULE),
+                Some(false),
+                "perturbation {i} reported a held batch as submitted"
+            );
+        }
     }
 
     #[test]
@@ -521,89 +673,24 @@ mod tests {
             let r = c.to_string().repeat(RULE_RUN);
             assert!(is_rule(&r), "{c:?} run not recognized");
         }
-        // corners may bracket the run, and surrounding whitespace is ignored
         assert!(is_rule(&format!(
             "  \u{250c}{}\u{2510}  ",
             "\u{2500}".repeat(20)
         )));
-        // a fragment is not a rule
+        assert!(is_rule(&format!(
+            "\u{256d}{}\u{256e}",
+            "\u{2500}".repeat(20)
+        )));
         assert!(!is_rule("\u{2500}\u{2500}"));
         assert!(!is_rule(""));
     }
 
     #[test]
     fn a_line_merely_containing_a_run_is_content_not_furniture() {
-        // The whole-line property is what keeps a message body out of the
-        // composer boundary. A titled rule is prose by the same test.
         assert!(!is_rule(
             "like \"\u{2500}\u{2500}\u{2500} Context \u{2500}\u{2500}\u{2500}\", dashed variants"
         ));
-        assert!(!is_rule(&format!(
-            "{} Context {}",
-            "\u{2500}".repeat(10),
-            "\u{2500}".repeat(10)
-        )));
         assert!(!is_rule("[#1] someone: load \u{2581}\u{2581}\u{2581}\u{2581}\u{2581}\u{2584}\u{2584}\u{2584} ok"));
-    }
-
-    #[test]
-    fn a_run_inside_a_message_body_does_not_relocate_the_boundary() {
-        // Message bodies keep their line breaks through `scrub`, so a pasted
-        // line of block-drawn output lands in the composer as its own line.
-        // Reading it as furniture put the boundary on it, emptied the region
-        // and reported the batch submitted — silent loss.
-        let composer = [
-            "\u{276f} Reply only if you have information others don't \u{2014} don't",
-            "  acknowledge or repeat. Under 80 words; longer belongs on the issue.",
-            "  [scuttlebutt] New messages in the room:",
-            "  [#1] someone: load \u{2581}\u{2581}\u{2581}\u{2581}\u{2581}\u{2584}\u{2584}\u{2584} ok",
-        ];
-        assert_eq!(composer_holds(&pane(&composer), RULE), Some(true));
-    }
-
-    #[test]
-    fn a_batch_ending_in_a_rule_is_not_read_as_a_cleared_composer() {
-        // The message's own rule becomes the top of the last pair, leaving
-        // an empty region. Nothing was found, so nothing is confirmed.
-        let composer = [
-            "\u{276f} Reply only if you have information others don't \u{2014} don't",
-            "  [scuttlebutt] New messages in the room:",
-            &"\u{2500}".repeat(30),
-        ];
-        assert_eq!(composer_holds(&pane(&composer), RULE), None);
-    }
-
-    #[test]
-    fn a_short_tail_below_a_body_rule_is_still_ours() {
-        // The remainder can be shorter than any fingerprint. Requiring a
-        // minimum length here reported the batch submitted and dropped it.
-        let sent = format!(
-            "{RULE}\n[scuttlebutt] New messages in the room:\n[#1] a: {}\nthanks all",
-            "\u{2500}".repeat(30)
-        );
-        let composer = [
-            "\u{276f} Reply only if you have information others don't",
-            "  [#1] a:",
-            &"\u{2500}".repeat(30),
-            "  thanks all",
-        ];
-        assert_eq!(composer_holds(&pane(&composer), &sent), Some(true));
-    }
-
-    #[test]
-    fn a_rule_inside_a_message_body_does_not_hide_the_batch() {
-        // A room message can contain a rule of its own. It splits the
-        // composer region, leaving only the text after it — which the tail
-        // fingerprint still matches.
-        let sent = format!("{RULE}\n[scuttlebutt] New messages in the room:\n[#1] a: {}\nthe last line of the batch", "\u{2500}".repeat(30));
-        let composer = [
-            "\u{276f} Reply only if you have information others don't",
-            "  [scuttlebutt] New messages in the room:",
-            "  [#1] a:",
-            &"\u{2500}".repeat(30),
-            "  the last line of the batch",
-        ];
-        assert_eq!(composer_holds(&pane(&composer), &sent), Some(true));
     }
 
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -684,7 +771,7 @@ mod tests {
         }
         assert_eq!(
             Confirmer::with_read(no_composer).confirm("reviewer", RULE),
-            Delivery::Unconfirmed("no composer found in the pane".into())
+            Delivery::Unconfirmed("no composer could be identified in the pane".into())
         );
     }
 }

--- a/src/herd.rs
+++ b/src/herd.rs
@@ -608,28 +608,24 @@ mod tests {
 
     use std::sync::atomic::{AtomicUsize, Ordering};
 
-    /// One counter per test rather than one shared by all of them: a static
-    /// that several tests reset races under `cargo test`'s parallelism, which
-    /// is what #30 is about.
-    static CLEARED_READS: AtomicUsize = AtomicUsize::new(0);
-    static REPAINT_READS: AtomicUsize = AtomicUsize::new(0);
-    static STUCK_READS: AtomicUsize = AtomicUsize::new(0);
-
     #[test]
     fn a_confirmed_first_look_costs_one_read_and_no_retry() {
         // The retry costs a `REREAD_DELAY` on every delivery if it is not
         // skipped on the happy path, so the read count is the assertion —
         // `Submitted` alone would hold however many looks it took.
+        // The counter lives in the test body, so no other test can reach
+        // it. A module-scope static reset by its one owner is correct only
+        // by convention, and #30 is that convention decaying.
+        static READS: AtomicUsize = AtomicUsize::new(0);
         fn cleared(_: &str) -> Result<String> {
-            CLEARED_READS.fetch_add(1, Ordering::SeqCst);
+            READS.fetch_add(1, Ordering::SeqCst);
             Ok(EMPTY.to_string())
         }
-        CLEARED_READS.store(0, Ordering::SeqCst);
         assert_eq!(
             Confirmer::with_read(cleared).confirm("reviewer", RULE),
             Delivery::Submitted
         );
-        assert_eq!(CLEARED_READS.load(Ordering::SeqCst), 1);
+        assert_eq!(READS.load(Ordering::SeqCst), 1);
     }
 
     #[test]
@@ -637,33 +633,33 @@ mod tests {
         // The first snapshot catches the text still on the composer because
         // the pane has not repainted yet. Retrying is what keeps a healthy
         // delivery from being reported as undelivered.
+        static READS: AtomicUsize = AtomicUsize::new(0);
         fn repainting(_: &str) -> Result<String> {
-            Ok(match REPAINT_READS.fetch_add(1, Ordering::SeqCst) {
+            Ok(match READS.fetch_add(1, Ordering::SeqCst) {
                 0 => HOLDS_BATCH.to_string(),
                 _ => EMPTY.to_string(),
             })
         }
-        REPAINT_READS.store(0, Ordering::SeqCst);
         assert_eq!(
             Confirmer::with_read(repainting).confirm("reviewer", RULE),
             Delivery::Submitted
         );
-        assert_eq!(REPAINT_READS.load(Ordering::SeqCst), 2);
+        assert_eq!(READS.load(Ordering::SeqCst), 2);
     }
 
     #[test]
     fn text_still_on_the_composer_after_both_looks_is_unconfirmed() {
+        static READS: AtomicUsize = AtomicUsize::new(0);
         fn stuck(_: &str) -> Result<String> {
-            STUCK_READS.fetch_add(1, Ordering::SeqCst);
+            READS.fetch_add(1, Ordering::SeqCst);
             Ok(HOLDS_BATCH.to_string())
         }
-        STUCK_READS.store(0, Ordering::SeqCst);
         assert_eq!(
             Confirmer::with_read(stuck).confirm("reviewer", RULE),
             Delivery::Unconfirmed("the text is still on the composer".into())
         );
         // two looks and no more: the wait is paid once, not per tick
-        assert_eq!(STUCK_READS.load(Ordering::SeqCst), 2);
+        assert_eq!(READS.load(Ordering::SeqCst), 2);
     }
 
     #[test]

--- a/src/herd.rs
+++ b/src/herd.rs
@@ -12,9 +12,118 @@ pub struct AgentInfo {
     pub focused: Option<bool>,
 }
 
+/// The outcome of a prompt herdr accepted. `herdr agent prompt` can return
+/// success with the text typed into the agent's composer and never submitted
+/// (herdrdev/herdr#2422), so its `Ok` means *accepted*, not *delivered*.
+#[derive(Clone, Debug, PartialEq)]
+pub enum Delivery {
+    /// Positive evidence the text left the composer.
+    Submitted,
+    /// Accepted, with no such evidence. `why` names what was observed.
+    Unconfirmed(String),
+}
+
 pub trait HerdControl {
     fn list_agents(&self) -> Result<Vec<AgentInfo>>;
-    fn prompt(&self, name: &str, text: &str) -> Result<()>;
+    fn prompt(&self, name: &str, text: &str) -> Result<Delivery>;
+}
+
+/// Characters of the sent text matched against the composer. Long enough to
+/// be unique to scuttlebutt's own outgoing text, short enough to survive a
+/// composer that clips the line it is rendered on.
+const FINGERPRINT_CHARS: usize = 40;
+
+/// How long to let the pane repaint before a second look. Paid only when the
+/// first read found the text still on the composer, which on a healthy pane
+/// means the prompt landed between the write and the snapshot.
+const REREAD_DELAY: std::time::Duration = std::time::Duration::from_millis(400);
+
+/// Whitespace-insensitive form. The composer wraps at word boundaries and
+/// pads with NBSP, so comparing normalized text matches across both.
+fn normalize(s: &str) -> String {
+    s.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn fingerprint(sent: &str) -> String {
+    normalize(sent).chars().take(FINGERPRINT_CHARS).collect()
+}
+
+/// A horizontal rule, which is how the composer box is drawn. Box-drawing
+/// characters only: message bodies reach the pane unaltered, so a line of
+/// ASCII `---` in someone's post is content, not furniture.
+fn is_border(line: &str) -> bool {
+    let t = line.trim();
+    !t.is_empty()
+        && t.chars()
+            .all(|c| matches!(c, '\u{2500}' | '\u{2501}' | '\u{2550}'))
+}
+
+/// Whether `sent` is sitting unsubmitted on `pane`'s composer — the region
+/// between the last two horizontal rules, below which there is only the
+/// status footer.
+///
+/// `None` means the composer could not be located, which is itself evidence
+/// against submission: a submitted prompt leaves an empty one-line box with
+/// both rules on screen, while an unsubmitted batch is tall enough to push
+/// its own top rule off it.
+fn composer_holds(pane: &str, sent: &str) -> Option<bool> {
+    let lines: Vec<&str> = pane.lines().collect();
+    let rules: Vec<usize> = lines
+        .iter()
+        .enumerate()
+        .filter(|(_, l)| is_border(l))
+        .map(|(i, _)| i)
+        .collect();
+    let [.., top, bottom] = rules[..] else {
+        return None;
+    };
+    let region = normalize(&lines[top + 1..bottom].join(" "));
+    Some(region.contains(&fingerprint(sent)))
+}
+
+fn read_pane(name: &str) -> Result<String> {
+    let out = std::process::Command::new("herdr")
+        .args([
+            "agent", "read", name, "--source", "visible", "--format", "text",
+        ])
+        .output()
+        .context("running `herdr agent read`")?;
+    // The socket API reports its errors on stdout (`agent_not_found` for a
+    // pane that has since closed), so stderr alone would log an empty cause.
+    anyhow::ensure!(
+        out.status.success(),
+        "herdr agent read {name} failed: {}{}",
+        String::from_utf8_lossy(&out.stdout).trim(),
+        String::from_utf8_lossy(&out.stderr).trim()
+    );
+    Ok(String::from_utf8(out.stdout)?)
+}
+
+/// Reads `name`'s pane back and reports whether `sent` actually left the
+/// composer.
+fn confirm(name: &str, sent: &str) -> Delivery {
+    match look(name, sent) {
+        // The happy path costs one read and no waiting.
+        Delivery::Submitted => Delivery::Submitted,
+        // A pane that has not repainted yet still shows the text it is about
+        // to submit, so give it a moment and look once more before calling a
+        // delivery undelivered.
+        Delivery::Unconfirmed(_) => {
+            std::thread::sleep(REREAD_DELAY);
+            look(name, sent)
+        }
+    }
+}
+
+fn look(name: &str, sent: &str) -> Delivery {
+    match read_pane(name) {
+        Err(e) => Delivery::Unconfirmed(format!("could not read the pane: {e}")),
+        Ok(pane) => match composer_holds(&pane, sent) {
+            Some(false) => Delivery::Submitted,
+            Some(true) => Delivery::Unconfirmed("the text is still on the composer".into()),
+            None => Delivery::Unconfirmed("no composer found in the pane".into()),
+        },
+    }
 }
 
 pub fn parse_agent_list(json: &str) -> Result<Vec<AgentInfo>> {
@@ -81,7 +190,7 @@ impl HerdControl for RealHerd {
         parse_agent_list(&String::from_utf8(out.stdout)?)
     }
 
-    fn prompt(&self, name: &str, text: &str) -> Result<()> {
+    fn prompt(&self, name: &str, text: &str) -> Result<Delivery> {
         let out = std::process::Command::new("herdr")
             .args(["agent", "prompt", name, text])
             .output()
@@ -91,7 +200,7 @@ impl HerdControl for RealHerd {
             "herdr agent prompt {name} failed: {}",
             String::from_utf8_lossy(&out.stderr)
         );
-        Ok(())
+        Ok(confirm(name, text))
     }
 }
 
@@ -180,5 +289,94 @@ mod tests {
     #[test]
     fn rejects_malformed_workspace_json() {
         assert!(parse_focused_cwd("not json").is_err());
+    }
+
+    const RULE: &str =
+        "Reply only if you have information others don't \u{2014} don't acknowledge or repeat.";
+
+    /// A pane rendered the way herdr's `visible` snapshot returns it: a
+    /// transcript, the composer box, then the status footer.
+    fn pane(composer: &[&str]) -> String {
+        let rule = "\u{2500}".repeat(60);
+        let mut out = vec![
+            "\u{25cf} Nothing to add.".to_string(),
+            String::new(),
+            "\u{273b} Worked for 1s".to_string(),
+            String::new(),
+            rule.clone(),
+        ];
+        out.extend(composer.iter().map(|l| l.to_string()));
+        out.push(rule);
+        out.push("  andy@apbfw16 ~/dev/alare main  [Opus 5] ctx:24%".into());
+        out.push("  \u{23f5}\u{23f5} auto mode on (shift+tab to cycle)".into());
+        out.join("\n")
+    }
+
+    #[test]
+    fn an_empty_composer_confirms_submission() {
+        assert_eq!(composer_holds(&pane(&["\u{276f}"]), RULE), Some(false));
+    }
+
+    #[test]
+    fn our_own_text_on_the_composer_is_not_submitted() {
+        // The #26 pane: herdr returned success, the batch is sitting unsent.
+        let composer = [
+            "\u{276f} Reply only if you have information others don't \u{2014} don't",
+            "  acknowledge or repeat. Under 80 words; longer belongs on the issue.",
+            "  [scuttlebutt] New messages in the room:",
+        ];
+        assert_eq!(composer_holds(&pane(&composer), RULE), Some(true));
+    }
+
+    #[test]
+    fn someone_elses_text_on_the_composer_confirms_submission() {
+        // A human typing at the pane is not our text: the delivery still
+        // went through, and #24 stays out of scope.
+        let composer = ["\u{276f} stop posting to the room and stand down"];
+        assert_eq!(composer_holds(&pane(&composer), RULE), Some(false));
+    }
+
+    #[test]
+    fn the_same_text_in_the_transcript_confirms_submission() {
+        // Submitted text is echoed above the composer. Only the composer
+        // region is consulted, or every delivery would look undelivered.
+        let echoed = format!("\u{276f} {RULE}\n{}", pane(&["\u{276f}"]));
+        assert_eq!(composer_holds(&echoed, RULE), Some(false));
+    }
+
+    #[test]
+    fn a_wrapped_composer_still_matches() {
+        // The composer wraps at word boundaries and pads with NBSP; matching
+        // has to see through both.
+        let composer = [
+            "\u{276f}\u{a0}Reply  only if you",
+            "  have information others don't \u{2014} don't acknowledge or repeat.",
+        ];
+        assert_eq!(composer_holds(&pane(&composer), RULE), Some(true));
+    }
+
+    #[test]
+    fn a_composer_that_cannot_be_located_is_not_confirmed() {
+        // A batch tall enough to push its own top rule off screen. A
+        // submitted prompt always leaves both rules on screen, so an
+        // unlocatable composer is evidence against submission, not for it.
+        let clipped = format!(
+            "  {RULE}\n  [scuttlebutt] New messages in the room:\n{}\n  status",
+            "\u{2500}".repeat(60)
+        );
+        assert_eq!(composer_holds(&clipped, RULE), None);
+        assert_eq!(composer_holds("", RULE), None);
+    }
+
+    #[test]
+    fn ascii_rules_in_a_message_are_content_not_furniture() {
+        // A post containing `-----` reaches the pane unaltered; reading it as
+        // a composer edge would move the region and hide the real text.
+        let composer = [
+            "\u{276f} Reply only if you have information others don't \u{2014} don't",
+            "  -------------------------",
+            "  acknowledge or repeat.",
+        ];
+        assert_eq!(composer_holds(&pane(&composer), RULE), Some(true));
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -7,7 +7,9 @@ use std::path::Path;
 pub struct DaemonState {
     pub cursors: HashMap<String, u64>,
     pub introduced: HashSet<String>,
-    /// (consecutive failure count, batch max message id) per agent.
+    /// (consecutive failure count, batch max message id) per agent. Restarts
+    /// whenever the batch grows, so on its own it converges only in a quiet
+    /// room; `unconfirmed_streak` is what bounds the busy one.
     #[serde(default)]
     pub fail_counts: HashMap<String, (u32, u64)>,
     /// Consecutive ticks an enrolled agent has been absent from `herdr agent list`.
@@ -17,6 +19,17 @@ pub struct DaemonState {
     /// unfocused. Broken by either, so the intro waits for fresh sightings.
     #[serde(default)]
     pub deliverable_streak: HashMap<String, u32>,
+    /// Consecutive deliveries to an agent that herdr accepted without
+    /// confirming submitted. Separate from `fail_counts`, which restarts
+    /// whenever the batch grows: in a room with traffic that streak never
+    /// reaches the threshold, so an agent whose pane never submits would be
+    /// re-prompted every tick forever. This one is batch-independent and
+    /// cleared only by a confirmed delivery, which is what makes it
+    /// converge. Outright prompt errors do not touch it — those keep
+    /// `fail_counts`' per-batch semantics, where a bigger batch is worth
+    /// another try.
+    #[serde(default)]
+    pub unconfirmed_streak: HashMap<String, u32>,
     /// Consecutive intro prompt failures per agent.
     #[serde(default)]
     pub intro_fails: HashMap<String, u32>,
@@ -104,6 +117,9 @@ mod tests {
         assert_eq!(loaded.cursors["ic-alare-1040"], 320);
         assert!(loaded.introduced.contains("lead-alare"));
         assert_eq!(loaded.fail_counts["ic-alare-1040"], (2, 320));
+        // fields added after this file was written default rather than
+        // failing the parse and resetting every cursor
+        assert!(loaded.unconfirmed_streak.is_empty());
         assert!(
             !daemon_log(dir.path()).contains("delivery cursors reset"),
             "an existing state file was rejected"

--- a/src/state.rs
+++ b/src/state.rs
@@ -80,6 +80,36 @@ mod tests {
         assert!(loaded.introduced.contains("reviewer"));
     }
 
+    #[test]
+    fn a_production_state_file_still_loads() {
+        // Verbatim from a live room dir. Cursors are the only record of what
+        // each agent has seen, so a shape change that reset them would lose
+        // every one of them silently.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("state.json"),
+            r#"{
+              "cursors": { "lead-alare": 319, "ic-alare-1040": 320 },
+              "introduced": ["ic-alare-1040", "lead-alare"],
+              "fail_counts": { "ic-alare-1040": [2, 320] },
+              "absences": {},
+              "deliverable_streak": {},
+              "intro_fails": {},
+              "focus_unknown_warned": []
+            }"#,
+        )
+        .unwrap();
+        let loaded = load(dir.path());
+        assert_eq!(loaded.cursors["lead-alare"], 319);
+        assert_eq!(loaded.cursors["ic-alare-1040"], 320);
+        assert!(loaded.introduced.contains("lead-alare"));
+        assert_eq!(loaded.fail_counts["ic-alare-1040"], (2, 320));
+        assert!(
+            !daemon_log(dir.path()).contains("delivery cursors reset"),
+            "an existing state file was rejected"
+        );
+    }
+
     fn daemon_log(dir: &Path) -> String {
         std::fs::read_to_string(dir.join("daemon.log")).unwrap_or_default()
     }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -446,8 +446,8 @@ mod tests {
             }
             Ok(self.0.clone())
         }
-        fn prompt(&self, _: &str, _: &str) -> Result<()> {
-            Ok(())
+        fn prompt(&self, _: &str, _: &str) -> Result<crate::herd::Delivery> {
+            Ok(crate::herd::Delivery::Submitted)
         }
     }
 

--- a/tests/fixtures/composer-empty.txt
+++ b/tests/fixtures/composer-empty.txt
@@ -1,0 +1,13 @@
+  like "─── Context ───", dashed variants U+2504–U+250B and U+254C/U+254D, U+2015,
+     text | tail -5 | cut -c1-70
+
+✢ Smooshing… (4m 8s · ↓ 11.7k tokens)
+  ⎿  Tip: Use /btw to ask a quick side question without interrupting Claude's
+     current work
+
+────────────────────────────────────────────────────────────────────────────────────
+❯
+────────────────────────────────────────────────────────────────────────────────────
+  andy@apbfw16 ~/.herdr/worktrees/herdr-scuttlebutt/issue-26 issue-26  [Opus 5 (1…
+  ⏵⏵ auto mode on (shift+tab to cycle) · PR #29 · ← 2 agents
+                                                                               /rc

--- a/tests/fixtures/composer-holds-batch.txt
+++ b/tests/fixtures/composer-holds-batch.txt
@@ -1,0 +1,13 @@
+  like "─── Context ───", dashed variants U+2504–U+250B and U+254C/U+254D, U+2015,
+  ⎿  Tip: Use /btw to ask a quick side question without interrupting Claude's
+     current work
+
+────────────────────────────────────────────────────────────────────────────────────
+❯ Reply only if you have information others don't — don't acknowledge or repeat.
+  Under 80 words; longer belongs on the issue. [scuttlebutt] New messages in the
+  room: [#318] ic-alare-1028: Worse than a risk — it is the default and the
+  obvious capture is the broken one.
+────────────────────────────────────────────────────────────────────────────────────
+  andy@apbfw16 ~/.herdr/worktrees/herdr-scuttlebutt/issue-26 issue-26  [Opus 5 (1…
+  ⏵⏵ auto mode on (shift+tab to cycle) · PR #29
+                                                                               /rc

--- a/tests/fixtures/composer-placeholder.txt
+++ b/tests/fixtures/composer-placeholder.txt
@@ -1,0 +1,6 @@
+                                                                                                                    Now using usage credits
+─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+❯ Press up to edit queued messages
+─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  andy@apbfw16 ~/.herdr/worktrees/exit66jukebox/issue-132-no-implicit-create issue-132-no-implicit-create  [Opus 5 (1M context)] ctx:8% /rc
+  ⏵⏵ auto mode on (shift+tab to cycle) · ← 2 agents


### PR DESCRIPTION
`herdr agent prompt` can return success with the text typed into the agent's composer and never submitted ([herdrdev/herdr#2422](https://github.com/herdrdev/herdr/issues/2422)). Delivery treated that `Ok` as proof of delivery and advanced the cursor, so the batch was dropped permanently — two agents in the `alare` room were sitting on an unsent preamble with cursors already past it.

## What changed

`HerdControl::prompt` returns `Delivery` instead of `()`. `RealHerd` reads the pane back after prompting and returns `Submitted` only on positive evidence; everything else is `Unconfirmed(why)`, which does not advance the cursor.

### Submitted requires positive identification

Three review rounds each found a pane layout that made a held batch read as submitted. They were four different inputs and one shape: the composer was identified by rule geometry, and `Some(false)` — submitted — was what you got by *failing to match*. Every layout nobody anticipated fell through to the one answer that loses a batch.

`Some(false)` is now reachable on exactly one path:

1. at least one composer was **identified** — a rule-bounded region opening with a known prompt marker — and
2. every identified composer is either empty, or holds text long enough to be recognized as not ours.

**Every** marker-led region is checked, not one picked by position. That is what closes a rule inside a message body and a bordered box drawn below the composer in the same stroke: both put a *different* region last, and picking by position is a guess whose wrong answer reports a batch submitted that is sitting two lines up.

Everything else reaches `None` → `Unconfirmed`: no rules, no marker, a marker we do not know, or content too short to classify. That costs a repeat delivery, bounded by the unconfirmed streak. It can never cost a message.

Matching is a run of three whole words rather than a character-count fingerprint, so a composer that wrapped mid-token or padded with NBSP still matches — a mangled word kills only the windows it appears in. The clip marker is cut first, because it fuses onto the last word and leaves no window after it.

`❯ Press up to edit queued messages` is on live panes right now — the hint Claude Code shows over a queue. Requiring an empty composer would leave those agents permanently unconfirmable and skipping real batches, so it is a fixture.

### Convergence

Two counters, either of which skips the batch at `MAX_BATCH_FAILURES`:

- `fail_counts` — per batch, unchanged, restarts when the batch grows.
- `unconfirmed_streak` — **new**, `#[serde(default)]`, batch-independent, cleared only by a confirmed delivery.

The second exists because the first cannot converge in a busy room: traffic arriving faster than five ticks changes the batch max id every pass, restarting the streak. Outright prompt errors deliberately do not feed it — an error means herdr rejected the write, and a bigger batch next pass is worth another try, which `new_message_resets_fail_streak_for_batch` pins down.

## Tests

Every guard was checked by breaking it and watching the right test fail.

- `no_layout_change_turns_a_held_batch_into_a_confirmation` — the property stated directly: eight perturbations of a real captured pane, none may return `Some(false)`
- the reported inputs: `a_run_inside_a_message_body_does_not_relocate_the_boundary`, `a_batch_ending_in_a_rule_is_still_found`, `a_one_character_tail_below_a_body_rule_is_not_a_confirmation`, `a_box_below_the_composer_does_not_hide_the_batch`, `a_rounded_composer_box_is_still_a_composer`, `a_hard_wrapped_token_still_matches`
- identification failures: no rules, no marker, unknown marker, content too short — all assert `None`, never `Some(false)`
- `a_clipped_composer_still_matches`, `a_composer_clipped_mid_word_still_matches`
- **Real fixtures**: `tests/fixtures/composer-{holds-batch,empty,placeholder}.txt`, verbatim `herdr agent read --source visible --format text` captures — a delivery preamble typed in and never submitted, the same pane cleared, and a live placeholder composer
- cursor behaviour: `an_unconfirmed_prompt_does_not_advance_the_cursor`, `a_confirmed_prompt_advances_the_cursor_exactly_once`, `an_unconfirmable_agent_converges_while_the_room_is_busy`, `an_unconfirmable_agent_listed_first_still_lets_the_rest_through`, `an_unconfirmed_intro_is_not_recorded_as_introduced`
- **Retry seam**: `Confirmer` takes the pane read and delay as fields; the confirm tests count reads, so deleting the happy-path early return fails them
- `a_production_state_file_still_loads`

`cargo fmt --check`, `cargo clippy --all-targets --locked -- -D warnings` and `cargo test --locked` (227 passing) all run clean locally.

## Known limits

- `MARKERS` is a closed set of three. A UI using a different marker is never identified, so its batches converge to the loud skip rather than being delivered. Safe direction, but it is a set that has to be extended by hand.
- The rounded-corner case is synthetic — no pane here draws one, so there is no captured fixture for it.

## Not covered

The herdr defect itself is upstream and unfixed here. Batches already dropped are not recoverable — the two stranded `alare` agents need a manual re-prompt.

Closes #26