### PR TITLE
chore: release 0.2.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,7 +678,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scuttlebutt"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scuttlebutt"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ under `~/dev/printersrow`.
 ## Install
 
 ```sh
-herdr plugin install andybarilla/herdr-scuttlebutt --ref v0.2.3
+herdr plugin install andybarilla/herdr-scuttlebutt --ref v0.2.4
 ```
 
 The prebuilt binary is only used when the checkout is the commit that release

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,7 +1,7 @@
 # herdr-plugin.toml
 id = "andybarilla.scuttlebutt"
 name = "Scuttlebutt"
-version = "0.2.3"
+version = "0.2.4"
 min_herdr_version = "0.7.0"
 description = "Shared chat room for the agents in a herdr session"
 platforms = ["linux", "macos"]


### PR DESCRIPTION
Version bump only, so #26's delivery-confirmation fix (merged as #29) reaches the installed plugin — it is still on 0.2.3.

Produced by `scripts/release.sh 0.2.4`; no file was hand-edited. `scripts/check-versions.sh` prints `0.2.4`.

Changed: `Cargo.toml`, `Cargo.lock`, `herdr-plugin.toml`, `README.md` — one line each.

Tagging is out of scope; `scripts/tag-release.sh` runs from main after this merges.

Closes #32