### PR TITLE
Identify a composer in the layouts this fleet actually runs

### DIFF
--- a/src/herd.rs
+++ b/src/herd.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use unicode_width::UnicodeWidthChar;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct AgentInfo {
@@ -121,163 +122,220 @@ fn is_joint(c: char) -> bool {
 /// Whether a line *is* a horizontal rule, which is how a composer box is
 /// drawn.
 ///
-/// The line has to open and close with box-drawing characters and carry a
-/// run of horizontals. Between them it may carry one label: Claude Code
-/// centres the session title in the top border of its composer
-/// (`\u{2500}\u{2500} clear-conversation-state \u{2500}\u{2500}`), which is #36 — requiring every
-/// character to be box-drawing rejected that border, left one rule in the
-/// pane, and identified no composer at all.
+/// The line has to open and close with box-drawing characters and carry an
+/// unbroken run of `RULE_RUN` horizontals. Between them it may carry one
+/// label: Claude Code writes the session title into the top border of its
+/// composer, right-aligned rather than centred — `\u{2500}\u{2500}\u{2500} clear-conversation-state \u{2500}`
+/// is 274 horizontals, the title, and one more — which is #36. Requiring
+/// every character to be box-drawing rejected that border, left one rule in
+/// the pane, and identified no composer at all.
 ///
-/// One label, not any number of them, and never at either end. That is what
-/// still separates furniture from content: a message body carrying
-/// box-drawn terminal output reaches the composer with its line breaks
-/// intact, and treating one of its lines as furniture would move a region
-/// boundary onto it. Such a line all but always has text outside the run —
-/// `like "\u{2500}\u{2500}\u{2500} Context \u{2500}\u{2500}\u{2500}", dashed variants` opens with a word.
+/// The unbroken run is measured per run rather than summed, so that a short
+/// centred label between two stubs — `\u{2500}\u{2500}\u{2500}\u{2500}\u{2500} Context \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}`, the shape a
+/// pasted transcript actually carries — stays content. That is a bound, not
+/// a guarantee: a body line carrying a long enough run and one label is
+/// indistinguishable from a titled border, and reading it as furniture
+/// splits the composer in two. Nothing in a line can settle that, so
+/// `rule_bounded` keeps the half without the marker rather than discarding
+/// it, and `composer_holds` still finds our text on it.
 fn is_rule(line: &str) -> bool {
     let line = line.trim();
     let boxed = |c: char| is_horizontal(c) || is_joint(c);
     if !line.starts_with(boxed) || !line.ends_with(boxed) {
         return false;
     }
-    let mut horizontals = 0;
+    // Horizontals per run of box-drawing characters, so a label breaks the
+    // run it interrupts rather than being summed across.
+    let mut runs = vec![0usize];
     let mut labels = 0;
     let mut in_label = false;
     for c in line.chars() {
         if boxed(c) {
-            in_label = false;
-            horizontals += usize::from(is_horizontal(c));
+            if in_label {
+                runs.push(0);
+                in_label = false;
+            }
+            *runs.last_mut().expect("a run is always open") += usize::from(is_horizontal(c));
         } else if !in_label {
             in_label = true;
             labels += 1;
         }
     }
-    horizontals >= RULE_RUN && labels <= 1
+    labels <= 1 && runs.iter().any(|r| *r >= RULE_RUN)
 }
 
-/// Every composer identified in `pane`, each as its own lines, normalized
-/// and stripped of the marker or gutter that identified it.
+/// What a pane's rules and gutters divide it into.
+///
+/// `composers` are the regions a marker or a gutter identified as one.
+/// `others` is every remaining rule-bounded region, and it exists because a
+/// region boundary can move: a rule inside a message body splits the
+/// composer, and the half carrying our text is then the half without the
+/// marker. Those regions can say our text is still on the composer; they
+/// can never say a composer is clear. Discarding them, which is what this
+/// did before, turned a moved boundary into `Some(false)` and dropped the
+/// batch.
+struct Regions {
+    composers: Vec<Vec<String>>,
+    others: Vec<Vec<String>>,
+}
+
+/// Every region of `pane` a composer could be, each as its own lines,
+/// normalized and stripped of the marker or gutter that identified it.
 ///
 /// Lines rather than one joined string because the two decisions want
 /// different views of a composer. Whether it holds our text reads best
 /// across the whole thing, since the composer wraps mid-sentence. Whether
 /// it is *clear* has to read line by line: a box that prints furniture of
-/// its own below the text — OpenCode's model footer — pads a two-word
-/// unsubmitted prompt past the word count that would otherwise call it too
-/// short to classify.
+/// its own below the text — OpenCode's model footer — is text that is not
+/// ours sitting beside a short unsubmitted prompt, and read as one string
+/// the two together are long enough to classify.
 ///
 /// The two layouts here are the two this fleet runs, and neither is a
 /// guess: a rule-bounded box that opens with a known prompt marker, and a
-/// gutter-bounded box at the bottom edge of the pane. A layout matching
-/// neither identifies nothing, which costs a repeat delivery.
-fn composer_regions(pane: &str) -> Vec<Vec<String>> {
+/// gutter-bounded box closed by a rule. A layout matching neither
+/// identifies nothing, which costs a repeat delivery.
+fn composer_regions(pane: &str) -> Regions {
     let lines: Vec<&str> = pane.lines().collect();
     let mut regions = rule_bounded(&lines);
-    regions.extend(gutter_bounded(&lines));
+    regions.composers.extend(gutter_bounded(&lines));
     regions
 }
 
-/// Every rule-bounded region that opens with a prompt marker.
+/// Every rule-bounded region, split by whether it opens with a prompt
+/// marker.
 ///
-/// Every such region is returned, not just the last one, and that is the
-/// point. A message body ending in a rule of its own, or a bordered box
-/// drawn below the composer, both put a *different* region last; picking one
+/// Every region is returned, not just the last one, and that is the point.
+/// A message body ending in a rule of its own, or a bordered box drawn
+/// below the composer, both put a *different* region last; picking one
 /// region by position is a guess, and a wrong guess here reports a batch
 /// submitted that is sitting on a composer two lines up. A transcript echo
-/// of a submitted prompt cannot be mistaken for one of these, because the
-/// transcript draws no rules around it.
-fn rule_bounded(lines: &[&str]) -> Vec<Vec<String>> {
+/// of a submitted prompt cannot be mistaken for a composer, because the
+/// transcript draws no rules around it — but it can still land in `others`,
+/// where the worst it costs is a repeat delivery.
+fn rule_bounded(lines: &[&str]) -> Regions {
     let rules: Vec<usize> = lines
         .iter()
         .enumerate()
         .filter(|(_, l)| is_rule(l))
         .map(|(i, _)| i)
         .collect();
-    rules
-        .windows(2)
-        .filter_map(|w| {
-            let mut region: Vec<String> = lines[w[0] + 1..w[1]]
-                .iter()
-                .map(|l| normalize(l))
-                .filter(|l| !l.is_empty())
-                .collect();
-            let first = region.first()?;
-            let marker = MARKERS.iter().find(|m| first.starts_with(**m))?.len();
-            region[0] = region[0][marker..].trim().to_string();
-            Some(region)
-        })
-        .collect()
+    let mut regions = Regions {
+        composers: Vec::new(),
+        others: Vec::new(),
+    };
+    for w in rules.windows(2) {
+        let mut region: Vec<String> = lines[w[0] + 1..w[1]]
+            .iter()
+            .map(|l| normalize(l))
+            .filter(|l| !l.is_empty())
+            .collect();
+        let marker = region
+            .first()
+            .and_then(|first| MARKERS.iter().find(|m| first.starts_with(**m)))
+            .map(|m| m.len());
+        match marker {
+            Some(marker) => {
+                region[0] = region[0][marker..].trim().to_string();
+                regions.composers.push(region);
+            }
+            None if !region.is_empty() => regions.others.push(region),
+            None => {}
+        }
+    }
+    regions
 }
 
-/// The columns a box occupies, read off the bottom edge that closes it.
+/// The columns a box occupies, read off the rule that closes it.
 ///
 /// A pane right-aligns furniture of its own outside that edge — OpenCode
 /// wraps a long working directory up the right margin, across the rows the
 /// composer is drawn on — and clipping to the box is what keeps that out of
 /// the composer's contents. Left in, it reads as text that is not ours: a
-/// two-word unsubmitted prompt beside it is no longer too short to
-/// classify, which is `Some(false)` and the batch gone.
+/// two-word unsubmitted prompt with a fragment of a path beside it is three
+/// words, which is no longer too short to classify, which is `Some(false)`
+/// and the batch gone.
 ///
-/// Columns are counted in characters. A row carrying a double-width
-/// character is clipped a little late and keeps a fragment of what sits
-/// beyond the edge, which can only add words to a row that already had our
-/// text on it. It cannot empty a row: nothing the composer draws lies
-/// outside its own box.
+/// Columns are display cells rather than characters, because that is what
+/// the pane was drawn in. Counting characters clips a row carrying a
+/// double-width character late, by one column per such character, and the
+/// fragment it keeps is exactly the furniture this exists to remove.
 fn box_span(border: &str) -> (usize, usize) {
     let start = border.chars().take_while(|c| c.is_whitespace()).count();
-    (start, border.trim_end().chars().count())
+    (start, display_width(border.trim_end()))
 }
 
-/// One row of a gutter-bounded box, clipped to the box, gutter stripped and
-/// normalized.
+/// Display width in terminal cells, which is what a pane's columns are.
+fn display_width(s: &str) -> usize {
+    s.chars().map(|c| c.width().unwrap_or(0)).sum()
+}
+
+/// One row of a gutter-bounded box, clipped to the box's columns, gutter
+/// stripped and normalized.
 fn boxed_row(row: &str, (start, end): (usize, usize)) -> String {
-    let clipped: String = row.chars().take(end).skip(start).collect();
-    normalize(clipped.trim_start_matches(|c| GUTTERS.contains(&c)))
+    let mut col = 0;
+    let mut clipped = String::new();
+    for c in row.chars() {
+        if col >= end {
+            break;
+        }
+        if col >= start {
+            clipped.push(c);
+        }
+        col += c.width().unwrap_or(0);
+    }
+    // Trimmed before the gutter is stripped, because the clip starts at the
+    // rule's own indent and a box's rows may be indented further than the
+    // rule that closes it.
+    normalize(
+        clipped
+            .trim_start()
+            .trim_start_matches(|c| GUTTERS.contains(&c)),
+    )
 }
 
-/// The composer of an editor that draws a vertical down every row of its
-/// input box instead of a rule above it. OpenCode draws one, and puts a
-/// single horizontal in the whole pane: the bottom edge of that box. One
-/// rule bounds no region, which is the other half of #36 — and no widening
+/// Every box drawn with a vertical down each of its rows and closed by a
+/// rule beneath them. OpenCode draws its composer that way and puts a
+/// single horizontal in the whole pane — the bottom edge of that box. One
+/// rule bounds no region, which is the other half of #36, and no widening
 /// of `is_rule` can reach it, because the rules it would need are not
 /// drawn.
 ///
-/// Identification is positional, and it has to be: this layout gives the
-/// composer no marker of its own, and it draws *submitted* messages in the
-/// transcript inside the same gutter. Sitting against the pane's bottom
-/// edge is what separates the composer from those echoes — an echo always
-/// has the rest of the transcript below it.
-fn gutter_bounded(lines: &[&str]) -> Option<Vec<String>> {
+/// Closed by a rule, rather than sitting at the bottom of the pane: this
+/// layout gives the composer no marker of its own and draws *submitted*
+/// messages in the transcript inside the same gutter, so something has to
+/// separate the two, and it is the rule underneath. An echo has the rest of
+/// the transcript below it instead. The composer is not always the lowest
+/// thing in the pane either — OpenCode centres its box on a fresh session,
+/// with the transcript hint and status line below — so "lowest" would be
+/// wrong as well as unpinned.
+///
+/// Every such box is returned rather than the last, for the same reason
+/// `rule_bounded` returns every region: a bordered overlay drawn below the
+/// composer is another box closed by a rule, and returning only the lowest
+/// would replace the composer with the overlay and report the batch
+/// submitted from under it.
+fn gutter_bounded(lines: &[&str]) -> Vec<Vec<String>> {
     let gutter = |l: &&str| l.trim_start().starts_with(|c| GUTTERS.contains(&c));
-    let bottom = lines.iter().rposition(|l| is_rule(l))?;
-    let mut top = bottom;
-    while top > 0 && gutter(&lines[top - 1]) {
-        top -= 1;
+    let mut boxes = Vec::new();
+    for (bottom, _) in lines.iter().enumerate().filter(|(_, l)| is_rule(l)) {
+        let mut top = bottom;
+        while top > 0 && gutter(&lines[top - 1]) {
+            top -= 1;
+        }
+        // A box, not a single bordered line: one gutter row above a rule is
+        // as easily a transcript echo that happens to end there.
+        if bottom - top < 2 {
+            continue;
+        }
+        let span = box_span(lines[bottom]);
+        boxes.push(
+            lines[top..bottom]
+                .iter()
+                .map(|l| boxed_row(l, span))
+                .collect(),
+        );
     }
-    // A box, not a single bordered line: one gutter line above the bottom
-    // edge is as easily a transcript echo that happens to end there.
-    if bottom - top < 2 {
-        return None;
-    }
-    let span = box_span(lines[bottom]);
-    let mut region: Vec<String> = lines[top..bottom]
-        .iter()
-        .map(|l| boxed_row(l, span))
-        .collect();
-    // OpenCode prints the agent and model inside the box, below a blank row
-    // and under anything typed. That is furniture: left in, it pads an
-    // empty composer to three words, and a short unsubmitted prompt beside
-    // it would read as too long to be ours rather than too short to
-    // classify — `Some(false)`, and the batch gone. It is dropped only when
-    // that exact shape is present, because dropping a line that turned out
-    // to be ours is the one error here that could also lose a batch.
-    let footer = region.len() >= 2
-        && !region[region.len() - 1].is_empty()
-        && region[region.len() - 2].is_empty();
-    if footer {
-        region.pop();
-    }
-    Some(region)
+    boxes
 }
 
 /// Whether `content` is a run of `sent` rather than something else on the
@@ -318,19 +376,25 @@ fn is_our_text(content: &str, sent: &str) -> bool {
 /// case that failed to match and fell through to `Submitted`. There is no
 /// fall-through here — a layout this does not understand cannot reach it.
 fn composer_holds(pane: &str, sent: &str) -> Option<bool> {
-    let regions = composer_regions(pane);
-    if regions.is_empty() {
+    let Regions { composers, others } = composer_regions(pane);
+    if composers.is_empty() {
         return None;
     }
     let sent = normalize(sent);
-    if regions.iter().any(|c| is_our_text(&c.join(" "), &sent)) {
+    if composers
+        .iter()
+        .chain(&others)
+        .any(|c| is_our_text(&c.join(" "), &sent))
+    {
         return Some(true);
     }
-    let lines = || regions.iter().flatten();
+    // Only a region something identified as a composer can say a composer
+    // is clear. `others` has already had its say above.
+    let rows = || composers.iter().flatten();
     // A composer showing a queue hint is showing neither our text nor a
     // clear box: the queue it names may hold our batch or may not, and
     // nothing in the pane says which.
-    if lines().any(|l| QUEUE_HINTS.iter().any(|h| l.contains(h))) {
+    if rows().any(|l| QUEUE_HINTS.iter().any(|h| l.contains(h))) {
         return None;
     }
     // Non-empty but too short to tell ours from a placeholder or a menu.
@@ -344,7 +408,7 @@ fn composer_holds(pane: &str, sent: &str) -> Option<bool> {
             .count();
         words == 0 || words >= OVERLAP_WORDS
     };
-    match lines().all(classifiable) {
+    match rows().all(classifiable) {
         true => Some(false),
         false => None,
     }
@@ -720,7 +784,7 @@ mod tests {
             ("opencode, a wrapped working directory", OC_WRAPPED_CWD),
         ] {
             assert!(
-                !composer_regions(pane).is_empty(),
+                !composer_regions(pane).composers.is_empty(),
                 "{name}: no composer identified"
             );
         }
@@ -794,8 +858,15 @@ mod tests {
         // composer. Confirming here is half the point of the fix: an echo
         // read as a composer answers `Some(true)` on every tick, and the
         // unconfirmed streak skips a batch just as surely as a failed
-        // delivery does. One region, and it is the composer.
-        assert_eq!(composer_regions(OC_LIVE).len(), 1);
+        // delivery does.
+        //
+        // What excludes them is the rule: no rule is drawn beneath an echo,
+        // so no echo closes a box. That is a weaker guarantee than it
+        // sounds — an overlay bordered below an echo would close one — and
+        // `an_overlay_below_a_gutter_composer_does_not_hide_the_batch` is
+        // what makes that survivable, by keeping every box rather than the
+        // lowest. One region here, and it is the composer.
+        assert_eq!(composer_regions(OC_LIVE).composers.len(), 1);
         assert_eq!(composer_holds(OC_LIVE, OC_SENT), Some(false));
     }
 
@@ -810,7 +881,7 @@ mod tests {
         // classify, and the pane is unconfirmable for as long as its
         // working directory is that long.
         for (name, pane) in [("an ic pane", OC_WRAPPED_CWD), ("a scratch pane", OC_EMPTY)] {
-            assert_eq!(composer_regions(pane).len(), 1, "{name}");
+            assert_eq!(composer_regions(pane).composers.len(), 1, "{name}");
             assert_eq!(composer_holds(pane, OC_SENT), Some(false), "{name}");
         }
     }
@@ -842,6 +913,129 @@ mod tests {
                 "{name}: a held batch reported submitted"
             );
         }
+    }
+
+    // ---- a boundary that moved never loses the batch --------------------
+
+    #[test]
+    fn a_short_centred_label_between_stubs_is_not_a_rule() {
+        // The shape a pasted transcript carries. Summing horizontals across
+        // the label instead of measuring the run would make this furniture,
+        // and furniture inside the composer splits it.
+        assert!(!is_rule("\u{2500}\u{2500}\u{2500}\u{2500}\u{2500} Context \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}"));
+        assert!(is_rule(&format!(
+            "{} Context \u{2500}",
+            "\u{2500}".repeat(RULE_RUN)
+        )));
+    }
+
+    #[test]
+    fn a_line_with_two_labels_is_not_a_rule() {
+        // One label is the session title. Two is a table row, a progress
+        // bar, or a body line, and each label it is allowed moves the bound
+        // further from anything a composer border does.
+        let run = "\u{2500}".repeat(RULE_RUN);
+        assert!(is_rule(&format!("{run} one {run}")));
+        assert!(!is_rule(&format!("{run} one {run} two {run}")));
+    }
+
+    #[test]
+    fn a_rule_inside_the_batch_does_not_hide_the_half_without_the_marker() {
+        // A message body carrying a titled rule of its own splits the
+        // composer, and our text ends up in the half the marker is not in.
+        // That half used to be discarded, which left the half holding a
+        // label — three words, none of them ours — to answer for the
+        // composer: `Some(false)`, cursor advanced, batch gone.
+        let titled = format!("{} Context \u{2500}", "\u{2500}".repeat(RULE_RUN));
+        let composer = [
+            format!("\u{276f} {titled}"),
+            titled,
+            "Reply only if you have information others don't".to_string(),
+        ];
+        assert_eq!(holds(&composer, RULE), Some(true));
+    }
+
+    #[test]
+    fn an_overlay_below_a_gutter_composer_does_not_hide_the_batch() {
+        // A bordered box drawn under an OpenCode composer is another
+        // gutter box closed by a rule. Taking only the lowest one replaces
+        // the composer with the overlay and reports the batch submitted
+        // from under it.
+        let overlay = format!(
+            "  \u{2503}\n  \u{2503}  Allow this command? [y/N]\n  \u{2503}\n{}",
+            "\u{2500}".repeat(60)
+        );
+        let pane = format!("{OC_HOLDS}{overlay}");
+        assert_eq!(composer_holds(&pane, OC_SENT), Some(true));
+    }
+
+    #[test]
+    fn a_single_gutter_row_above_a_rule_is_not_a_composer() {
+        // One bordered row is as easily the last line of a transcript echo
+        // that happens to end above a rule. Read as a composer it is four
+        // words that are not ours, which is a confirmation.
+        let pane = format!(
+            "  \u{2503}  someone else was here\n{}\n  status",
+            "\u{2500}".repeat(60)
+        );
+        assert_eq!(composer_holds(&pane, RULE), None);
+    }
+
+    #[test]
+    fn a_gutter_composer_is_found_above_the_bottom_of_the_pane() {
+        // OpenCode centres its box on a fresh session, with a transcript
+        // hint and a status line below it. The rule beneath the rows is
+        // what closes the box; being lowest in the pane is not.
+        let rule = OC_HINT
+            .lines()
+            .position(is_rule)
+            .expect("fixture lost its box");
+        assert!(
+            rule < OC_HINT.lines().count() - 2,
+            "fixture no longer has content below the box"
+        );
+        assert_eq!(composer_regions(OC_HINT).composers.len(), 1);
+    }
+
+    #[test]
+    fn a_double_width_character_does_not_pull_furniture_into_a_row() {
+        // Clipping by characters rather than display cells runs one column
+        // late per double-width character, and what it keeps is the first
+        // character of the working directory wrapped up the right margin.
+        // Beside two words of ours that fragment is a third word, which is
+        // enough to classify — and classified, an unsubmitted prompt is
+        // submitted. Built on the real pane that wraps its cwd, with one
+        // row of the box replaced.
+        let mut lines: Vec<String> = OC_WRAPPED_CWD.lines().map(String::from).collect();
+        let bottom = lines
+            .iter()
+            .position(|l| is_rule(l))
+            .expect("fixture lost its box");
+        let span = box_span(&lines[bottom]);
+        let held = "  \u{2503}  Reply\u{1f389} only";
+        let furniture = "~/.herdr/worktrees/alare/issue-1076:";
+        lines[bottom - 3] = format!(
+            "{held}{}{furniture}",
+            " ".repeat(span.1 - display_width(held))
+        );
+        let pane = lines.join("\n");
+
+        assert_eq!(boxed_row(&lines[bottom - 3], span), "Reply\u{1f389} only");
+        assert_eq!(composer_holds(&pane, OC_SENT), None);
+    }
+
+    #[test]
+    fn a_gutter_box_without_a_footer_still_holds_what_is_in_it() {
+        // The model footer used to be popped off the last row on its shape
+        // alone — non-empty, blank row above it. A composer holding two
+        // words has exactly that shape, and popping it left rows that were
+        // all empty, which is a cleared composer. Per-row classification
+        // does the work the pop was there for, so there is nothing to pop.
+        let pane = format!(
+            "  \u{2503}\n  \u{2503}\n  \u{2503}  Reply only\n{}\n  status",
+            "\u{2500}".repeat(60)
+        );
+        assert_eq!(composer_holds(&pane, RULE), None);
     }
 
     // ---- nothing identified is never a confirmation ---------------------

--- a/src/herd.rs
+++ b/src/herd.rs
@@ -45,8 +45,18 @@ pub trait HerdControl {
 const MARKERS: [&str; 2] = ["\u{276f}", "\u{203a}"];
 
 /// Verticals an editor may draw down the left edge of its input box on
-/// every row, in place of a rule above it. OpenCode uses the heavy one.
-const GUTTERS: [char; 2] = ['\u{2503}', '\u{2502}'];
+/// every row, in place of a rule above it. OpenCode draws the heavy one.
+///
+/// The light `\u{2502}` was here and is not one. It is what a rendered markdown
+/// table draws its rows with, and a table cell that wraps puts two of them
+/// straight above the table's own bottom rule — a gutter box, by every test
+/// this applies. `gutter_bounded` has no second rule to measure a box
+/// against, so nothing downstream would have caught it: the region is a
+/// composer, and a cell quoting `DELIVERY_RULE` is a composer holding our
+/// batch forever. Same defect as a bare `>` in `MARKERS`, one function
+/// over. An editor that really did draw a light gutter would identify
+/// nothing here, which costs a repeat.
+const GUTTERS: [char; 1] = ['\u{2503}'];
 
 /// Fragments of what a composer shows in place of its contents while a
 /// queue is holding messages — Claude Code shows `\u{276f} Press up to edit queued
@@ -182,6 +192,15 @@ fn is_rule(line: &str) -> bool {
 /// neither can they ever say one is. Discarding them, which is what this
 /// did before, turned a moved boundary into `Some(false)` and dropped the
 /// batch.
+///
+/// No captured pane produces an `other`, and the tests that reach one are
+/// synthetic. Reaching one takes a rule inside the composer drawn at the
+/// box's own column and width, and a real composer indents what it holds,
+/// so a pasted rule lands a column or two in and matches nothing. Kept
+/// anyway, deliberately: nothing else stands between that shape and a
+/// dropped batch, what it costs when it does fire is a repeat rather than a
+/// drop, and every layout this has been wrong about so far was one nobody
+/// had captured either.
 struct Regions {
     composers: Vec<Vec<String>>,
     others: Vec<Vec<String>>,
@@ -220,14 +239,20 @@ fn same_box(top: &str, bottom: &str) -> bool {
 /// Every rule-bounded region that could be a composer, split by whether it
 /// opens with a prompt marker.
 ///
-/// A region counts only when its two rules could be the edges of one box.
-/// That is what keeps a transcript out: a rendered markdown table draws
-/// rules of its own, and this room's traffic is full of tables — the region
-/// between two of those rules carries a row that begins with `DELIVERY_RULE`
-/// and therefore matches every batch we ever send, forever. Matching edges
-/// exclude it, because a table's border is not the composer's width. Read
-/// without that test, the pane in `composer-below-a-table` answers
-/// `Some(true)` on a clear composer on every tick.
+/// What has to be kept out is the transcript. A rendered markdown table
+/// draws rules of its own, and this room's traffic is full of tables — the
+/// region between two of those rules carries a row that begins with
+/// `DELIVERY_RULE` and therefore matches every batch we ever send, forever.
+/// Two separate tests keep it out, and they do different jobs. Measured on
+/// `composer-below-a-table`, whose table separators all span `(2, 90)`:
+///
+/// - The table's own regions *do* match as boxes — a table is a box. What
+///   excludes them is that neither sits beside a composer. Without that,
+///   the pane answers `Some(true)` on a clear composer on every tick.
+/// - Matching edges exclude the region between the table and the composer,
+///   which spans two rules of different widths and would otherwise be an
+///   `other` beside the composer, vetoing forever. Without it, the same
+///   pane answers `None` on every tick.
 ///
 /// Every qualifying region is returned, not just the last one, and that is
 /// the point. A message body ending in a rule of its own, or a bordered box
@@ -309,8 +334,23 @@ fn box_span(border: &str) -> (usize, usize) {
 }
 
 /// Display width in terminal cells, which is what a pane's columns are.
+///
+/// `U+FE0F` promotes what precedes it: `unicode-width` reports the variation
+/// selector as zero and leaves `\u{26a0}` at one cell, while a terminal draws
+/// the emoji presentation in two. It matters because a composer's two rules
+/// are measured independently and have to agree — a label a cell narrower
+/// than it is drawn makes them disagree, and identifies no composer at all.
 fn display_width(s: &str) -> usize {
-    s.chars().map(|c| c.width().unwrap_or(0)).sum()
+    let mut width = 0;
+    let mut last = 0;
+    for c in s.chars() {
+        last = match c {
+            '\u{fe0f}' => 2 - last.min(2),
+            _ => c.width().unwrap_or(0),
+        };
+        width += last;
+    }
+    width
 }
 
 /// One row of a gutter-bounded box, clipped to the box's columns, gutter
@@ -742,6 +782,8 @@ mod tests {
     const OC_LIVE: &str = include_str!("../tests/fixtures/opencode-live-room.txt");
     const OC_WRAPPED_CWD: &str = include_str!("../tests/fixtures/opencode-wrapped-cwd.txt");
     const TABLE: &str = include_str!("../tests/fixtures/composer-below-a-table.txt");
+    const WRAPPED_TABLE: &str =
+        include_str!("../tests/fixtures/composer-below-a-wrapped-table.txt");
 
     /// What was typed into the OpenCode panes: `RULE` as a real delivery
     /// carries it, with the sentence that follows it in the preamble.
@@ -996,6 +1038,51 @@ mod tests {
     }
 
     #[test]
+    fn an_emoji_presentation_label_measures_the_cells_it_is_drawn_in() {
+        // A composer's two rules are measured independently and have to
+        // agree. `unicode-width` reports `\u{26a0}\u{fe0f}` as one cell and a terminal
+        // draws two, so a title carrying one would make the top border
+        // measure narrower than the bottom, pair with nothing, and identify
+        // no composer for as long as the session kept that title.
+        assert_eq!(display_width("\u{26a0}\u{fe0f}"), 2);
+        let run = "\u{2500}".repeat(RULE_RUN);
+        let titled = format!("{run} \u{26a0}\u{fe0f} {run}");
+        let plain = "\u{2500}".repeat(display_width(&titled));
+        assert!(same_box(&titled, &plain));
+        let pane = format!("{titled}\n\u{276f} Reply only if you have\n{plain}\n  status");
+        assert_eq!(composer_holds(&pane, RULE), Some(true));
+    }
+
+    #[test]
+    fn a_wrapped_table_cell_is_not_a_gutter_composer() {
+        // A real Claude Code pane, narrow enough that a table cell wraps,
+        // so three light-vertical rows sit straight above the table's own
+        // bottom rule. That is a gutter box by every test `gutter_bounded`
+        // applies, and it has no second rule for `same_box` to measure — so
+        // the cell, which quotes `DELIVERY_RULE`, is a composer holding our
+        // batch on every tick. Read with the light vertical still a gutter,
+        // this pane gives two composers and `Some(true)`.
+        assert!(WRAPPED_TABLE.contains('\u{2502}'), "fixture lost its table");
+        assert_eq!(composer_regions(WRAPPED_TABLE).composers.len(), 1);
+        assert_eq!(composer_holds(WRAPPED_TABLE, RULE), Some(false));
+    }
+
+    #[test]
+    fn two_rules_ending_at_one_column_are_not_one_box() {
+        // `box_span` reads both edges of the box, and both are load-bearing.
+        // A rule quoted into the batch, indented and shorter, can end at
+        // exactly the column the composer's border ends at — comparing only
+        // where they end pairs the two and splits the box between them.
+        let rule = "\u{2500}".repeat(60);
+        let inset = format!("    {}", "\u{2500}".repeat(56));
+        assert_eq!(box_span(&rule).1, box_span(&inset).1);
+        assert!(same_box(&rule, &rule));
+        assert!(!same_box(&rule, &inset));
+        let composer = ["\u{276f}".to_string(), inset, "  Done.".to_string()];
+        assert_eq!(holds(&composer, RULE), None);
+    }
+
+    #[test]
     fn a_blockquote_is_not_a_prompt_marker() {
         // `>` opens a markdown blockquote and a shell continuation line as
         // readily as it opens anyone's composer, and no agent this fleet
@@ -1227,7 +1314,7 @@ mod tests {
         // repeats. Drawn to the same width, the half without the marker is
         // kept beside the half with it, and it still holds us.
         let narrow = held(&[&"\u{2500}".repeat(30)]);
-        assert_ne!(holds(&narrow, RULE), Some(false));
+        assert_eq!(holds(&narrow, RULE), None);
         let matching = held(&[&"\u{2500}".repeat(60)]);
         assert_eq!(holds(&matching, RULE), Some(true));
     }
@@ -1237,10 +1324,15 @@ mod tests {
         // A tail too short to be recognized as ours, below a rule that
         // arrived inside the batch. Whether the rule matches the box or not,
         // the answer may never be that the composer is clear.
-        for body in [30, 60] {
-            let composer = held(&[&"\u{2500}".repeat(body), "  -"]);
-            assert_ne!(holds(&composer, RULE), Some(false), "body rule of {body}");
-        }
+        let narrow = held(&[&"\u{2500}".repeat(30), "  -"]);
+        assert_eq!(holds(&narrow, RULE), None);
+        let matching = held(&[&"\u{2500}".repeat(60), "  -"]);
+        assert_eq!(holds(&matching, RULE), Some(true));
+        // The rule a pasted transcript actually carries: one short label
+        // between two stubs, which is not furniture at all, so the composer
+        // is never split and still reads as holding us.
+        let titled = held(&["\u{2500}\u{2500}\u{2500}\u{2500}\u{2500} Context \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}"]);
+        assert_eq!(holds(&titled, RULE), Some(true));
     }
 
     #[test]

--- a/src/herd.rs
+++ b/src/herd.rs
@@ -361,7 +361,11 @@ fn box_span(border: &str) -> (usize, usize) {
 /// keeps the furniture it exists to remove.
 ///
 /// A selector with nothing to promote, or one after a character already two
-/// cells wide, adds nothing.
+/// cells wide, adds nothing. A second consecutive selector promotes again,
+/// so `\u{26a0}\u{fe0f}\u{fe0f}` measures three where a terminal draws two. Left alone
+/// deliberately: over-counting a row clips it early, which can only shorten
+/// what a composer is read as holding, and shortening is the direction that
+/// costs a repeat rather than a batch.
 fn cell_width(c: char, previous: usize) -> usize {
     match c {
         '\u{fe0f}' => usize::from(previous == 1),
@@ -994,15 +998,27 @@ mod tests {
         // unconfirmed streak skips a batch just as surely as a failed
         // delivery does.
         //
-        // What excludes them is the rule beneath the composer's rows, which
-        // no echo has. "No rule is drawn beneath an echo" was the claim
-        // here and it is false: a message body carrying a table or a `---`
-        // puts one inside the echo's own gutter, which is
-        // `a_rule_inside_a_gutter_row_does_not_box_the_transcript`. What
-        // holds is narrower — a rule inside a gutter row is not this box's
-        // edge, and an overlay bordered below an echo would close a real
-        // box, which is survivable only because every box is kept rather
-        // than the lowest. One region here, and it is the composer.
+        // What excludes them here is that no rule is drawn beneath any of
+        // them. That is a property of this pane, not a guarantee, and two
+        // rounds of this comment claiming otherwise is why it is spelled
+        // out. A rule inside an echo's own gutter row — a table or a `---`
+        // in a message body — is covered, by
+        // `a_rule_inside_a_gutter_row_does_not_box_the_transcript`. A rule
+        // drawn on its own line directly beneath an echo's block is not:
+        // inserting one `\u{2579}\u{2580}\u{2580}\u{2580}` line below an echo here yields that echo as
+        // a region holding our batch, and `Some(true)` on a clear composer
+        // for as long as the pane stands.
+        //
+        // Accepted rather than closed. No capture shows a rule beside an
+        // echo, every OpenCode pane we have carries exactly one rule, the
+        // shape needs no blank row between the two blocks, and what it
+        // costs is the bounded `Some(true)` — a stall that holds the batch
+        // — rather than a drop.
+        //
+        // Note what does *not* help: `composer_holds` returns on the first
+        // region matching our text, so keeping every box rather than the
+        // lowest never enters into this. That serves the opposite case, an
+        // overlay drawn below a real composer.
         assert_eq!(composer_regions(OC_LIVE).composers.len(), 1);
         assert_eq!(composer_holds(OC_LIVE, OC_SENT), Some(false));
     }
@@ -1181,6 +1197,51 @@ mod tests {
         assert_eq!(display_width("\u{26a0}\u{fe0f}"), 2);
         // Already two cells; the selector adds nothing to it.
         assert_eq!(display_width("\u{1f389}\u{fe0f}"), 2);
+    }
+
+    /// A pane's own composer rows replaced with the batch, keeping both of
+    /// its borders so the box still measures as one.
+    fn holding(pane: &str) -> String {
+        let mut lines: Vec<&str> = pane.lines().collect();
+        let top = lines
+            .iter()
+            .rposition(|l| is_rule(l))
+            .and_then(|bottom| lines[..bottom].iter().rposition(|l| is_rule(l)))
+            .expect("pane lost its composer");
+        let bottom = top
+            + lines[top..]
+                .iter()
+                .skip(1)
+                .position(|l| is_rule(l))
+                .expect("pane lost its composer")
+            + 1;
+        let batch: Vec<&str> = HOLDS_BATCH
+            .lines()
+            .skip_while(|l| !l.starts_with('\u{276f}'))
+            .take_while(|l| !is_rule(l))
+            .collect();
+        lines.splice(top + 1..bottom, batch);
+        lines.join("\n")
+    }
+
+    #[test]
+    fn a_table_pane_holding_a_batch_is_not_confirmed() {
+        // The cross-product the suite was missing. Tables were tested only
+        // against a clear composer and held batches only against
+        // table-free panes, so the one shape nobody covered was the one
+        // where a moved boundary costs a batch rather than an agent: a
+        // pane whose transcript draws rules *and* whose composer still
+        // holds us.
+        for (name, pane) in [
+            ("a rendered table", TABLE),
+            ("a table with a wrapped cell", WRAPPED_TABLE),
+        ] {
+            let held = holding(pane);
+            let regions = composer_regions(&held);
+            assert_eq!(regions.composers.len(), 1, "{name}");
+            assert!(regions.others.is_empty(), "{name}");
+            assert_eq!(composer_holds(&held, RULE), Some(true), "{name}");
+        }
     }
 
     #[test]

--- a/src/herd.rs
+++ b/src/herd.rs
@@ -161,11 +161,23 @@ fn is_rule(line: &str) -> bool {
     if !line.starts_with(boxed) || !line.ends_with(boxed) {
         return false;
     }
+    // A gutter opens a row of a box; it never opens that box's edge. Left in,
+    // `\u{2503}  \u{251c}\u{2500}\u{2500}\u{2500}\u{2524}` — a table separator inside a message OpenCode has
+    // already taken — is a rule, and `gutter_bounded` walks up from it and
+    // boxes the transcript above as a composer.
+    if line.starts_with(|c| GUTTERS.contains(&c)) {
+        return false;
+    }
     // Horizontals per run of box-drawing characters, so a label breaks the
     // run it interrupts rather than being summed across.
     let mut runs = vec![0usize];
     let mut labels = 0;
     let mut in_label = false;
+    // A gap is not a title. A line that puts two pieces of furniture side by
+    // side — a gutter and a rule, a bordered cell holding a rule — separates
+    // them with spaces, and reading the whole line as one rule moves a
+    // region boundary onto a row that was never an edge.
+    let mut blank_label = false;
     for c in line.chars() {
         if boxed(c) {
             if in_label {
@@ -176,9 +188,13 @@ fn is_rule(line: &str) -> bool {
         } else if !in_label {
             in_label = true;
             labels += 1;
+            blank_label = true;
+        }
+        if !boxed(c) {
+            blank_label &= c.is_whitespace();
         }
     }
-    labels <= 1 && runs.iter().any(|r| *r >= RULE_RUN)
+    labels <= 1 && !blank_label && runs.iter().any(|r| *r >= RULE_RUN)
 }
 
 /// What a pane's rules and gutters divide it into.
@@ -333,22 +349,33 @@ fn box_span(border: &str) -> (usize, usize) {
     (start, display_width(border.trim_end()))
 }
 
-/// Display width in terminal cells, which is what a pane's columns are.
+/// The cells one character is drawn in, given what the character before it
+/// measured.
 ///
 /// `U+FE0F` promotes what precedes it: `unicode-width` reports the variation
-/// selector as zero and leaves `\u{26a0}` at one cell, while a terminal draws
-/// the emoji presentation in two. It matters because a composer's two rules
-/// are measured independently and have to agree — a label a cell narrower
-/// than it is drawn makes them disagree, and identifies no composer at all.
+/// selector as zero and leaves `\u{26a0}` at one cell, while a terminal draws the
+/// emoji presentation in two. It is the *only* character whose width depends
+/// on its neighbour here, which is why the dependency is threaded through
+/// rather than hidden — a column has to mean the same thing to everything
+/// that measures one. Two metrics over one coordinate space is how a clip
+/// keeps the furniture it exists to remove.
+///
+/// A selector with nothing to promote, or one after a character already two
+/// cells wide, adds nothing.
+fn cell_width(c: char, previous: usize) -> usize {
+    match c {
+        '\u{fe0f}' => usize::from(previous == 1),
+        _ => c.width().unwrap_or(0),
+    }
+}
+
+/// Display width in terminal cells, which is what a pane's columns are.
 fn display_width(s: &str) -> usize {
     let mut width = 0;
-    let mut last = 0;
+    let mut previous = 0;
     for c in s.chars() {
-        last = match c {
-            '\u{fe0f}' => 2 - last.min(2),
-            _ => c.width().unwrap_or(0),
-        };
-        width += last;
+        previous = cell_width(c, previous);
+        width += previous;
     }
     width
 }
@@ -357,6 +384,7 @@ fn display_width(s: &str) -> usize {
 /// stripped and normalized.
 fn boxed_row(row: &str, (start, end): (usize, usize)) -> String {
     let mut col = 0;
+    let mut previous = 0;
     let mut clipped = String::new();
     for c in row.chars() {
         if col >= end {
@@ -365,7 +393,8 @@ fn boxed_row(row: &str, (start, end): (usize, usize)) -> String {
         if col >= start {
             clipped.push(c);
         }
-        col += c.width().unwrap_or(0);
+        previous = cell_width(c, previous);
+        col += previous;
     }
     // Trimmed before the gutter is stripped, because the clip starts at the
     // rule's own indent and a box's rows may be indented further than the
@@ -965,12 +994,15 @@ mod tests {
         // unconfirmed streak skips a batch just as surely as a failed
         // delivery does.
         //
-        // What excludes them is the rule: no rule is drawn beneath an echo,
-        // so no echo closes a box. That is a weaker guarantee than it
-        // sounds — an overlay bordered below an echo would close one — and
-        // `an_overlay_below_a_gutter_composer_does_not_hide_the_batch` is
-        // what makes that survivable, by keeping every box rather than the
-        // lowest. One region here, and it is the composer.
+        // What excludes them is the rule beneath the composer's rows, which
+        // no echo has. "No rule is drawn beneath an echo" was the claim
+        // here and it is false: a message body carrying a table or a `---`
+        // puts one inside the echo's own gutter, which is
+        // `a_rule_inside_a_gutter_row_does_not_box_the_transcript`. What
+        // holds is narrower — a rule inside a gutter row is not this box's
+        // edge, and an overlay bordered below an echo would close a real
+        // box, which is survivable only because every box is kept rather
+        // than the lowest. One region here, and it is the composer.
         assert_eq!(composer_regions(OC_LIVE).composers.len(), 1);
         assert_eq!(composer_holds(OC_LIVE, OC_SENT), Some(false));
     }
@@ -1051,6 +1083,89 @@ mod tests {
         assert!(same_box(&titled, &plain));
         let pane = format!("{titled}\n\u{276f} Reply only if you have\n{plain}\n  status");
         assert_eq!(composer_holds(&pane, RULE), Some(true));
+    }
+
+    #[test]
+    fn a_row_and_its_box_are_measured_the_same_way() {
+        // `box_span` promoted an emoji-presentation sequence to the two
+        // cells a terminal draws it in and `boxed_row` did not, so the clip
+        // ran a cell late per sequence and kept the start of the working
+        // directory wrapped up the right margin. Beside two words of ours
+        // that is a third word, and a third word classifies: `Some(false)`
+        // on a prompt still sitting on the composer.
+        //
+        // `\u{26a0}\u{fe0f}` and not `\u{1f389}`, because the two metrics have to disagree
+        // about the character for the test to see the difference between
+        // them — `\u{1f389}` is two cells under both.
+        assert_ne!(
+            display_width("\u{26a0}\u{fe0f}"),
+            "\u{26a0}\u{fe0f}"
+                .chars()
+                .map(|c| c.width().unwrap_or(0))
+                .sum::<usize>(),
+            "the metrics agree, so this proves nothing"
+        );
+        let mut lines: Vec<String> = OC_WRAPPED_CWD.lines().map(String::from).collect();
+        let bottom = lines
+            .iter()
+            .position(|l| is_rule(l))
+            .expect("fixture lost its box");
+        let span = box_span(&lines[bottom]);
+        let held = "  \u{2503}  Reply\u{26a0}\u{fe0f} only";
+        lines[bottom - 3] = format!(
+            "{held}{}~/.herdr/worktrees/alare",
+            " ".repeat(span.1 - display_width(held))
+        );
+        assert_eq!(
+            boxed_row(&lines[bottom - 3], span),
+            "Reply\u{26a0}\u{fe0f} only"
+        );
+        assert_eq!(composer_holds(&lines.join("\n"), OC_SENT), None);
+    }
+
+    #[test]
+    fn a_rule_inside_a_gutter_row_does_not_box_the_transcript() {
+        // OpenCode draws messages it has already taken in the same gutter as
+        // its composer, and a message body carrying a table or a `---` puts a
+        // rule inside one of those rows. Read as a rule, `gutter_bounded`
+        // walks up from it and boxes the echo above as a composer — holding
+        // the batch it quotes, on every tick, forever.
+        //
+        // That is why `a_clear_gutter_drawn_composer_confirms_submission`
+        // could not carry the guarantee on its own: "no rule is drawn beneath
+        // an echo" is false for any message body containing one.
+        let separator = format!("  \u{2503}  \u{251c}{}\u{2524}", "\u{2500}".repeat(16));
+        let plain = format!("  \u{2503}  {}", "\u{2500}".repeat(16));
+        // Two guards keep those out, and each has a shape only it catches.
+        // A gutter with the run against it carries no label at all; a
+        // bordered table cell holding a rule is not gutter-led.
+        let run = "\u{2500}".repeat(RULE_RUN * 2);
+        assert!(!is_rule(&format!("\u{2503}{run}")), "gutter against a run");
+        assert!(
+            !is_rule(&format!("\u{2502}  {run}")),
+            "a cell holding a rule"
+        );
+        for injected in [separator, plain] {
+            assert!(!is_rule(&injected), "{injected:?} read as a rule");
+            let pane: Vec<String> = OC_EMPTY
+                .lines()
+                .map(|l| match l.contains("[scuttlebutt] New messages") {
+                    true => injected.clone(),
+                    false => l.to_string(),
+                })
+                .collect();
+            let pane = pane.join("\n");
+            assert_eq!(composer_regions(&pane).composers.len(), 1);
+            assert_eq!(composer_holds(&pane, OC_SENT), Some(false));
+        }
+    }
+
+    #[test]
+    fn a_variation_selector_with_nothing_to_promote_measures_nothing() {
+        assert_eq!(display_width("\u{fe0f}"), 0);
+        assert_eq!(display_width("\u{26a0}\u{fe0f}"), 2);
+        // Already two cells; the selector adds nothing to it.
+        assert_eq!(display_width("\u{1f389}\u{fe0f}"), 2);
     }
 
     #[test]

--- a/src/herd.rs
+++ b/src/herd.rs
@@ -35,7 +35,14 @@ pub trait HerdControl {
 /// costs a repeat. Guessing instead resolves to `Submitted` and costs the
 /// batch. A gutter-bounded composer has no marker and is identified by
 /// `gutter_bounded` instead.
-const MARKERS: [&str; 3] = ["\u{276f}", ">", "\u{203a}"];
+///
+/// A bare `>` was here and is not a marker. No agent this fleet runs opens
+/// its composer with one — Claude Code draws `\u{276f}`, OpenCode draws no marker
+/// at all — and `>` is what markdown opens a blockquote with and what a
+/// shell draws for a continuation line. A marker that ordinary text also
+/// starts with turns transcript into a composer, and a composer that is
+/// really transcript answers for the pane.
+const MARKERS: [&str; 2] = ["\u{276f}", "\u{203a}"];
 
 /// Verticals an editor may draw down the left edge of its input box on
 /// every row, in place of a rule above it. OpenCode uses the heavy one.
@@ -167,11 +174,12 @@ fn is_rule(line: &str) -> bool {
 /// What a pane's rules and gutters divide it into.
 ///
 /// `composers` are the regions a marker or a gutter identified as one.
-/// `others` is every remaining rule-bounded region, and it exists because a
-/// region boundary can move: a rule inside a message body splits the
-/// composer, and the half carrying our text is then the half without the
-/// marker. Those regions can say our text is still on the composer; they
-/// can never say a composer is clear. Discarding them, which is what this
+/// `others` are the regions beside a composer that carry no marker, and
+/// they exist because a region boundary can move: a rule inside a message
+/// body splits the composer, and the half carrying our text is then the
+/// half without the marker. Those regions can say our text is still on the
+/// composer, and their mere presence stops a composer claiming to be clear;
+/// neither can they ever say one is. Discarding them, which is what this
 /// did before, turned a moved boundary into `Some(false)` and dropped the
 /// batch.
 struct Regions {
@@ -201,17 +209,38 @@ fn composer_regions(pane: &str) -> Regions {
     regions
 }
 
-/// Every rule-bounded region, split by whether it opens with a prompt
-/// marker.
+/// Whether two rules could be the two edges of one box: drawn at the same
+/// column, to the same width. A composer's borders are; a rule that arrived
+/// inside a message body, or the border of a table in the transcript, has
+/// no reason to match the composer's and in practice does not.
+fn same_box(top: &str, bottom: &str) -> bool {
+    box_span(top) == box_span(bottom)
+}
+
+/// Every rule-bounded region that could be a composer, split by whether it
+/// opens with a prompt marker.
 ///
-/// Every region is returned, not just the last one, and that is the point.
-/// A message body ending in a rule of its own, or a bordered box drawn
-/// below the composer, both put a *different* region last; picking one
+/// A region counts only when its two rules could be the edges of one box.
+/// That is what keeps a transcript out: a rendered markdown table draws
+/// rules of its own, and this room's traffic is full of tables — the region
+/// between two of those rules carries a row that begins with `DELIVERY_RULE`
+/// and therefore matches every batch we ever send, forever. Matching edges
+/// exclude it, because a table's border is not the composer's width. Read
+/// without that test, the pane in `composer-below-a-table` answers
+/// `Some(true)` on a clear composer on every tick.
+///
+/// Every qualifying region is returned, not just the last one, and that is
+/// the point. A message body ending in a rule of its own, or a bordered box
+/// drawn below the composer, both put a *different* region last; picking one
 /// region by position is a guess, and a wrong guess here reports a batch
-/// submitted that is sitting on a composer two lines up. A transcript echo
-/// of a submitted prompt cannot be mistaken for a composer, because the
-/// transcript draws no rules around it — but it can still land in `others`,
-/// where the worst it costs is a repeat delivery.
+/// submitted that is sitting on a composer two lines up.
+///
+/// `others` — regions that qualify but carry no marker — are kept only next
+/// to a composer, because that is the one place a composer's own content
+/// can be: a rule that arrives inside the box splits it, and the half
+/// holding our text is then the half without the marker. They can say our
+/// text is still there; they can never say a composer is clear. Kept
+/// further afield, they are the transcript again, vetoing forever.
 fn rule_bounded(lines: &[&str]) -> Regions {
     let rules: Vec<usize> = lines
         .iter()
@@ -219,11 +248,12 @@ fn rule_bounded(lines: &[&str]) -> Regions {
         .filter(|(_, l)| is_rule(l))
         .map(|(i, _)| i)
         .collect();
-    let mut regions = Regions {
-        composers: Vec::new(),
-        others: Vec::new(),
-    };
+    let mut boxed: Vec<Option<(bool, Vec<String>)>> = Vec::new();
     for w in rules.windows(2) {
+        if !same_box(lines[w[0]], lines[w[1]]) {
+            boxed.push(None);
+            continue;
+        }
         let mut region: Vec<String> = lines[w[0] + 1..w[1]]
             .iter()
             .map(|l| normalize(l))
@@ -236,10 +266,24 @@ fn rule_bounded(lines: &[&str]) -> Regions {
         match marker {
             Some(marker) => {
                 region[0] = region[0][marker..].trim().to_string();
-                regions.composers.push(region);
+                boxed.push(Some((true, region)));
             }
-            None if !region.is_empty() => regions.others.push(region),
-            None => {}
+            None if region.is_empty() => boxed.push(None),
+            None => boxed.push(Some((false, region))),
+        }
+    }
+    let composer_at = |i: usize| matches!(boxed.get(i), Some(Some((true, _))));
+    let mut regions = Regions {
+        composers: Vec::new(),
+        others: Vec::new(),
+    };
+    for (i, region) in boxed.iter().enumerate() {
+        match region {
+            Some((true, lines)) => regions.composers.push(lines.clone()),
+            Some((false, lines)) if composer_at(i + 1) || (i > 0 && composer_at(i - 1)) => {
+                regions.others.push(lines.clone())
+            }
+            _ => {}
         }
     }
     regions
@@ -387,6 +431,14 @@ fn composer_holds(pane: &str, sent: &str) -> Option<bool> {
         .any(|c| is_our_text(&c.join(" "), &sent))
     {
         return Some(true);
+    }
+    // A region kept in `others` is a rule inside the box with content on
+    // the far side of it, so which half is the composer's is exactly what
+    // cannot be told apart. The marker half saying it is empty is not
+    // evidence the box is: our text may be the half that lost the marker,
+    // mangled past a three-word window and so unable to say so above.
+    if !others.is_empty() {
+        return None;
     }
     // Only a region something identified as a composer can say a composer
     // is clear. `others` has already had its say above.
@@ -689,6 +741,7 @@ mod tests {
     const OC_HINT: &str = include_str!("../tests/fixtures/opencode-hint.txt");
     const OC_LIVE: &str = include_str!("../tests/fixtures/opencode-live-room.txt");
     const OC_WRAPPED_CWD: &str = include_str!("../tests/fixtures/opencode-wrapped-cwd.txt");
+    const TABLE: &str = include_str!("../tests/fixtures/composer-below-a-table.txt");
 
     /// What was typed into the OpenCode panes: `RULE` as a real delivery
     /// carries it, with the sentence that follows it in the preamble.
@@ -782,6 +835,7 @@ mod tests {
             ("opencode, holding a batch", OC_HOLDS),
             ("opencode, a working lead", OC_LIVE),
             ("opencode, a wrapped working directory", OC_WRAPPED_CWD),
+            ("claude code, a table above the composer", TABLE),
         ] {
             assert!(
                 !composer_regions(pane).composers.is_empty(),
@@ -802,19 +856,28 @@ mod tests {
 
     #[test]
     fn a_titled_border_over_a_held_batch_is_not_a_confirmation() {
-        // The two halves put together: the real titled border from one pane
-        // above the real held batch of another. Live panes gave each shape
-        // separately, and it is their combination that would drop a batch.
-        let titled = TITLED
-            .lines()
-            .find(|l| l.contains("clear-conversation-state"))
-            .expect("fixture lost its titled border");
-        let mut lines: Vec<&str> = HOLDS_BATCH.lines().collect();
+        // The real titled pane with the real held rows written into its
+        // composer. Both of its borders are kept, so the box still measures
+        // as one: splicing only the top border in would have changed the
+        // box's width and tested nothing but the mismatch.
+        let mut lines: Vec<&str> = TITLED.lines().collect();
         let top = lines
             .iter()
-            .position(|l| is_rule(l))
-            .expect("fixture lost its composer border");
-        lines[top] = titled;
+            .position(|l| l.contains("clear-conversation-state"))
+            .expect("fixture lost its titled border");
+        let bottom = top
+            + lines[top..]
+                .iter()
+                .skip(1)
+                .position(|l| is_rule(l))
+                .expect("fixture lost its composer")
+            + 1;
+        let batch: Vec<&str> = HOLDS_BATCH
+            .lines()
+            .skip_while(|l| !l.starts_with('\u{276f}'))
+            .take_while(|l| !is_rule(l))
+            .collect();
+        lines.splice(top + 1..bottom, batch);
         assert_eq!(composer_holds(&lines.join("\n"), RULE), Some(true));
     }
 
@@ -915,6 +978,48 @@ mod tests {
         }
     }
 
+    #[test]
+    fn a_table_in_the_transcript_is_not_a_composer() {
+        // A real Claude Code pane with a rendered markdown table above a
+        // clear composer, one of whose rows carries `DELIVERY_RULE` — which
+        // opens every batch we send, so it matches all of them, forever.
+        // Read without matching the box's edges, this pane answers
+        // `Some(true)` on every tick and the streak skips the batch: #36's
+        // symptom, from the fix for #36.
+        assert!(
+            TABLE.lines().filter(|l| is_rule(l)).count() > 2,
+            "fixture lost its table"
+        );
+        assert_eq!(composer_regions(TABLE).composers.len(), 1);
+        assert!(composer_regions(TABLE).others.is_empty());
+        assert_eq!(composer_holds(TABLE, RULE), Some(false));
+    }
+
+    #[test]
+    fn a_blockquote_is_not_a_prompt_marker() {
+        // `>` opens a markdown blockquote and a shell continuation line as
+        // readily as it opens anyone's composer, and no agent this fleet
+        // runs opens one with it. Read as a marker, a quoted line between
+        // two rules of matching width is a composer holding whatever it
+        // quotes.
+        let quoted = ["> Reply only if you have information others don't".to_string()];
+        assert_eq!(holds(&quoted, RULE), None);
+    }
+
+    #[test]
+    fn a_closing_rule_with_a_wide_label_measures_its_box_in_cells() {
+        // `box_span` reads the box's columns off the rule that closes it.
+        // Counted in characters, a double-width label makes that rule
+        // measure narrower than it is drawn, and the rows above are clipped
+        // short — far enough, on a narrow box, to cut our text off
+        // entirely and leave rows that are all empty, which reads as clear.
+        let run = "\u{2500}".repeat(RULE_RUN);
+        let bottom = format!("{run} \u{6982}\u{8981} {run}");
+        let pane = format!("  \u{2503}\n  \u{2503}  Reply only\n  \u{2503}\n{bottom}\n  status");
+        assert_eq!(box_span(&bottom), (0, display_width(&bottom)));
+        assert_ne!(composer_holds(&pane, RULE), Some(false));
+    }
+
     // ---- a boundary that moved never loses the batch --------------------
 
     #[test]
@@ -941,18 +1046,42 @@ mod tests {
 
     #[test]
     fn a_rule_inside_the_batch_does_not_hide_the_half_without_the_marker() {
-        // A message body carrying a titled rule of its own splits the
-        // composer, and our text ends up in the half the marker is not in.
-        // That half used to be discarded, which left the half holding a
-        // label — three words, none of them ours — to answer for the
-        // composer: `Some(false)`, cursor advanced, batch gone.
-        let titled = format!("{} Context \u{2500}", "\u{2500}".repeat(RULE_RUN));
+        // A rule pasted into the batch at exactly the box's width splits it
+        // into two regions that both look like the box's own. The marker
+        // half here is bare, and read alone it is a cleared composer:
+        // `Some(false)`, cursor advanced, batch gone. The half without the
+        // marker is what says otherwise.
+        let rule = "\u{2500}".repeat(60);
         let composer = [
-            format!("\u{276f} {titled}"),
-            titled,
+            "\u{276f}".to_string(),
+            rule,
             "Reply only if you have information others don't".to_string(),
         ];
         assert_eq!(holds(&composer, RULE), Some(true));
+    }
+
+    #[test]
+    fn a_bare_marker_beside_a_split_box_does_not_confirm() {
+        // The same split, with a tail too short for a three-word window to
+        // recognize as ours. Nothing can say the text is still there, so
+        // nothing may say it is gone either.
+        let rule = "\u{2500}".repeat(60);
+        let composer = ["\u{276f}".to_string(), rule, "  Done.".to_string()];
+        assert_eq!(holds(&composer, RULE), None);
+    }
+
+    #[test]
+    fn a_body_rule_of_another_width_identifies_no_box() {
+        // The same shape with the pasted rule at a different width and
+        // indent, which is what a pasted rule usually looks like. No two
+        // rules in the pane can be one box's edges, so nothing is
+        // identified at all.
+        let composer = [
+            "\u{276f}".to_string(),
+            format!("    {}", "\u{2500}".repeat(16)),
+            "  Done.".to_string(),
+        ];
+        assert_eq!(holds(&composer, RULE), None);
     }
 
     #[test]
@@ -1025,6 +1154,16 @@ mod tests {
     }
 
     #[test]
+    fn a_box_indented_further_than_its_closing_rule_still_reads() {
+        // The clip starts at the rule's own indent, so a box whose rows are
+        // indented past it keeps its gutter character as content. Every row
+        // is then one word, nothing classifies, and the pane is
+        // unconfirmable for as long as it is drawn that way.
+        let span = box_span(&"\u{2500}".repeat(60));
+        assert_eq!(boxed_row("    \u{2503}  Reply only", span), "Reply only");
+    }
+
+    #[test]
     fn a_gutter_box_without_a_footer_still_holds_what_is_in_it() {
         // The model footer used to be popped off the last row on its shape
         // alone — non-empty, blank row above it. A composer holding two
@@ -1082,18 +1221,26 @@ mod tests {
 
     #[test]
     fn a_batch_ending_in_a_rule_is_still_found() {
-        // The message's own rule splits the composer in two. The half that
-        // opens with the marker is still a composer and still holds us.
-        let composer = held(&[&"\u{2500}".repeat(30)]);
-        assert_eq!(holds(&composer, RULE), Some(true));
+        // The message's own rule splits the composer in two. Drawn to a
+        // different width than the box, no pair of rules in the pane can be
+        // that box's edges, so nothing is identified and the delivery
+        // repeats. Drawn to the same width, the half without the marker is
+        // kept beside the half with it, and it still holds us.
+        let narrow = held(&[&"\u{2500}".repeat(30)]);
+        assert_ne!(holds(&narrow, RULE), Some(false));
+        let matching = held(&[&"\u{2500}".repeat(60)]);
+        assert_eq!(holds(&matching, RULE), Some(true));
     }
 
     #[test]
     fn a_one_character_tail_below_a_body_rule_is_not_a_confirmation() {
-        // The tail region has no marker, so it is not a composer at all; the
-        // half above it is, and it holds the batch.
-        let composer = held(&[&"\u{2500}".repeat(30), "  -"]);
-        assert_eq!(holds(&composer, RULE), Some(true));
+        // A tail too short to be recognized as ours, below a rule that
+        // arrived inside the batch. Whether the rule matches the box or not,
+        // the answer may never be that the composer is clear.
+        for body in [30, 60] {
+            let composer = held(&[&"\u{2500}".repeat(body), "  -"]);
+            assert_ne!(holds(&composer, RULE), Some(false), "body rule of {body}");
+        }
     }
 
     #[test]

--- a/src/herd.rs
+++ b/src/herd.rs
@@ -40,12 +40,20 @@ const MARKERS: [&str; 3] = ["\u{276f}", ">", "\u{203a}"];
 /// every row, in place of a rule above it. OpenCode uses the heavy one.
 const GUTTERS: [char; 2] = ['\u{2503}', '\u{2502}'];
 
-/// Text a composer shows in place of its contents while a queue is holding
-/// messages. It is not ours and not a human's, and — this is the point —
-/// it hides the queue rather than describing it, so it cannot tell us
-/// whether our batch reached that queue or never left `herdr agent prompt`.
-/// Recognized so a word count cannot read it as a cleared composer.
-const QUEUE_HINTS: [&str; 1] = ["Press up to edit queued messages"];
+/// Fragments of what a composer shows in place of its contents while a
+/// queue is holding messages — Claude Code shows `\u{276f} Press up to edit queued
+/// messages`. Such a hint is not ours and not a human's, and — this is the
+/// point — it hides the queue rather than describing it, so it cannot tell
+/// us whether our batch reached that queue or never left `herdr agent
+/// prompt`. Recognized so a word count cannot read it as a cleared
+/// composer.
+///
+/// A fragment rather than the whole line, because the whole line is the
+/// part that moves: a count, a plural, or an appended key hint would stop
+/// an exact match firing, and the pane would fall back to `Some(false)` —
+/// silently, since nothing in the delivery path can tell a hint it failed
+/// to recognize from a composer that is genuinely clear.
+const QUEUE_HINTS: [&str; 1] = ["queued messages"];
 
 /// Words of the composer that must reappear, in order, in what we sent
 /// before the composer counts as holding our text. Three rather than a
@@ -201,28 +209,30 @@ fn rule_bounded(lines: &[&str]) -> Vec<Vec<String>> {
         .collect()
 }
 
-/// One row of a gutter-bounded box, gutter stripped and normalized.
+/// The columns a box occupies, read off the bottom edge that closes it.
 ///
-/// A pane may right-align furniture of its own across the box's rows —
-/// OpenCode wraps a long working directory up the right edge, over the
-/// composer — and a gap of several spaces is what separates the two. The
-/// row is cut at the first such gap.
+/// A pane right-aligns furniture of its own outside that edge — OpenCode
+/// wraps a long working directory up the right margin, across the rows the
+/// composer is drawn on — and clipping to the box is what keeps that out of
+/// the composer's contents. Left in, it reads as text that is not ours: a
+/// two-word unsubmitted prompt beside it is no longer too short to
+/// classify, which is `Some(false)` and the batch gone.
 ///
-/// A row whose *whole* content is right-aligned furniture keeps it instead
-/// of being cut to nothing, and that asymmetry is the safe direction: an
-/// empty row is evidence of a clear composer, and a cut must never
-/// manufacture that evidence out of a row that had something on it. Held
-/// text keeps matching either way, because `is_our_text` reads the region
-/// as one string and our text is what sits left of the gap.
-fn boxed_row(row: &str) -> String {
-    let row = row
-        .trim_start()
-        .trim_start_matches(|c| GUTTERS.contains(&c));
-    let left = normalize(row.split("   ").next().unwrap_or_default());
-    match left.is_empty() {
-        true => normalize(row),
-        false => left,
-    }
+/// Columns are counted in characters. A row carrying a double-width
+/// character is clipped a little late and keeps a fragment of what sits
+/// beyond the edge, which can only add words to a row that already had our
+/// text on it. It cannot empty a row: nothing the composer draws lies
+/// outside its own box.
+fn box_span(border: &str) -> (usize, usize) {
+    let start = border.chars().take_while(|c| c.is_whitespace()).count();
+    (start, border.trim_end().chars().count())
+}
+
+/// One row of a gutter-bounded box, clipped to the box, gutter stripped and
+/// normalized.
+fn boxed_row(row: &str, (start, end): (usize, usize)) -> String {
+    let clipped: String = row.chars().take(end).skip(start).collect();
+    normalize(clipped.trim_start_matches(|c| GUTTERS.contains(&c)))
 }
 
 /// The composer of an editor that draws a vertical down every row of its
@@ -249,7 +259,11 @@ fn gutter_bounded(lines: &[&str]) -> Option<Vec<String>> {
     if bottom - top < 2 {
         return None;
     }
-    let mut region: Vec<String> = lines[top..bottom].iter().map(|l| boxed_row(l)).collect();
+    let span = box_span(lines[bottom]);
+    let mut region: Vec<String> = lines[top..bottom]
+        .iter()
+        .map(|l| boxed_row(l, span))
+        .collect();
     // OpenCode prints the agent and model inside the box, below a blank row
     // and under anything typed. That is furniture: left in, it pads an
     // empty composer to three words, and a short unsubmitted prompt beside
@@ -316,7 +330,7 @@ fn composer_holds(pane: &str, sent: &str) -> Option<bool> {
     // A composer showing a queue hint is showing neither our text nor a
     // clear box: the queue it names may hold our batch or may not, and
     // nothing in the pane says which.
-    if lines().any(|l| QUEUE_HINTS.contains(&l.as_str())) {
+    if lines().any(|l| QUEUE_HINTS.iter().any(|h| l.contains(h))) {
         return None;
     }
     // Non-empty but too short to tell ours from a placeholder or a menu.
@@ -610,6 +624,7 @@ mod tests {
     const OC_SHORT: &str = include_str!("../tests/fixtures/opencode-short.txt");
     const OC_HINT: &str = include_str!("../tests/fixtures/opencode-hint.txt");
     const OC_LIVE: &str = include_str!("../tests/fixtures/opencode-live-room.txt");
+    const OC_WRAPPED_CWD: &str = include_str!("../tests/fixtures/opencode-wrapped-cwd.txt");
 
     /// What was typed into the OpenCode panes: `RULE` as a real delivery
     /// carries it, with the sentence that follows it in the preamble.
@@ -702,6 +717,7 @@ mod tests {
             ("opencode, clear", OC_EMPTY),
             ("opencode, holding a batch", OC_HOLDS),
             ("opencode, a working lead", OC_LIVE),
+            ("opencode, a wrapped working directory", OC_WRAPPED_CWD),
         ] {
             assert!(
                 !composer_regions(pane).is_empty(),
@@ -739,6 +755,21 @@ mod tests {
     }
 
     #[test]
+    fn a_queue_hint_that_has_moved_still_confirms_nothing() {
+        // Synthetic, and that is the point: the hint's wording is the part
+        // most likely to change under us, and an exact match failing to
+        // fire fails toward `Some(false)`, which is the verdict that loses
+        // the batch. Pinned so that shape cannot come back.
+        for hint in [
+            "Press up to edit 3 queued messages",
+            "Press up to edit queued messages (esc to clear)",
+        ] {
+            let composer = [format!("\u{276f} {hint}")];
+            assert_eq!(holds(&composer, RULE), None, "{hint:?} was classified");
+        }
+    }
+
+    #[test]
     fn a_gutter_drawn_composer_holding_a_batch_is_not_confirmed() {
         assert_eq!(composer_holds(OC_HOLDS, OC_SENT), Some(true));
     }
@@ -769,15 +800,19 @@ mod tests {
     }
 
     #[test]
-    fn furniture_right_aligned_over_the_composer_costs_confirmation() {
-        // `opencode-empty` is the same clear composer, in a pane whose
-        // working directory is long enough that OpenCode wraps it up the
-        // right edge, across the composer's rows. Its rows are cut at the
-        // gap, but a row that is *only* furniture keeps it rather than
-        // reading as blank — so this costs a repeat delivery instead of
-        // confirming a composer nothing was read from.
-        assert_eq!(composer_regions(OC_EMPTY).len(), 1);
-        assert_eq!(composer_holds(OC_EMPTY, OC_SENT), None);
+    fn furniture_right_aligned_over_the_composer_is_not_its_contents() {
+        // Two clear composers in panes whose working directory is long
+        // enough that OpenCode wraps it up the right margin, across the
+        // rows the box is drawn on. `opencode-wrapped-cwd` is a live IC
+        // pane, and it was found by running this locator over every pane in
+        // the fleet rather than over the captures: read as composer
+        // contents, those fragments are one word each, too short to
+        // classify, and the pane is unconfirmable for as long as its
+        // working directory is that long.
+        for (name, pane) in [("an ic pane", OC_WRAPPED_CWD), ("a scratch pane", OC_EMPTY)] {
+            assert_eq!(composer_regions(pane).len(), 1, "{name}");
+            assert_eq!(composer_holds(pane, OC_SENT), Some(false), "{name}");
+        }
     }
 
     #[test]

--- a/src/herd.rs
+++ b/src/herd.rs
@@ -28,11 +28,24 @@ pub trait HerdControl {
     fn prompt(&self, name: &str, text: &str) -> Result<Delivery>;
 }
 
-/// Prompt markers a composer opens with. Identification is by this set
-/// rather than "any punctuation": a marker we do not know is a composer we
-/// have not identified, which resolves to `Unconfirmed` and costs a repeat.
-/// Guessing instead resolves to `Submitted` and costs the batch.
+/// Prompt markers a rule-bounded composer opens with. Identification is by
+/// this set rather than "any punctuation": a marker we do not know is a
+/// composer we have not identified, which resolves to `Unconfirmed` and
+/// costs a repeat. Guessing instead resolves to `Submitted` and costs the
+/// batch. A gutter-bounded composer has no marker and is identified by
+/// `gutter_bounded` instead.
 const MARKERS: [&str; 3] = ["\u{276f}", ">", "\u{203a}"];
+
+/// Verticals an editor may draw down the left edge of its input box on
+/// every row, in place of a rule above it. OpenCode uses the heavy one.
+const GUTTERS: [char; 2] = ['\u{2503}', '\u{2502}'];
+
+/// Text a composer shows in place of its contents while a queue is holding
+/// messages. It is not ours and not a human's, and — this is the point —
+/// it hides the queue rather than describing it, so it cannot tell us
+/// whether our batch reached that queue or never left `herdr agent prompt`.
+/// Recognized so a word count cannot read it as a cleared composer.
+const QUEUE_HINTS: [&str; 1] = ["Press up to edit queued messages"];
 
 /// Words of the composer that must reappear, in order, in what we sent
 /// before the composer counts as holding our text. Three rather than a
@@ -55,27 +68,36 @@ fn normalize(s: &str) -> String {
     s.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
-/// Whether a line *is* a horizontal rule, which is how a composer box is
-/// drawn. Any of the box-drawing horizontals counts — heavy, double, dashed,
-/// block — since which one a terminal UI picks is its own business, and
-/// corners (square or rounded), tees and verticals may bracket the run.
-///
-/// The whole line has to be rule characters. A line that merely contains a
-/// run is content: a message body carrying box-drawn terminal output reaches
-/// the composer with its line breaks intact, and treating one of its lines as
-/// furniture would move a region boundary onto it.
-fn is_rule(line: &str) -> bool {
-    let line = line.trim();
-    let mut horizontals = 0;
-    for c in line.chars() {
-        match c {
-            // light, heavy, dashed and double horizontals; the horizontal
-            // bar and extension; the block halves a UI may rule with
-            '\u{2500}' | '\u{2501}' | '\u{2504}' | '\u{2505}' | '\u{2508}' | '\u{2509}'
-            | '\u{254c}' | '\u{254d}' | '\u{2550}' | '\u{2015}' | '\u{23af}' | '\u{2580}'
-            | '\u{2581}' | '\u{2584}' | '\u{2594}' => horizontals += 1,
-            // corners, tees, verticals and half-lines may bracket or join it
-            '\u{2502}'
+/// The horizontals a rule is drawn from: light, heavy, dashed and double;
+/// the horizontal bar and extension; the block halves a UI may rule with.
+/// Which one a terminal UI picks is its own business.
+fn is_horizontal(c: char) -> bool {
+    matches!(
+        c,
+        '\u{2500}'
+            | '\u{2501}'
+            | '\u{2504}'
+            | '\u{2505}'
+            | '\u{2508}'
+            | '\u{2509}'
+            | '\u{254c}'
+            | '\u{254d}'
+            | '\u{2550}'
+            | '\u{2015}'
+            | '\u{23af}'
+            | '\u{2580}'
+            | '\u{2581}'
+            | '\u{2584}'
+            | '\u{2594}'
+    )
+}
+
+/// Box-drawing furniture that may bracket or join a run: corners (square or
+/// rounded), tees, verticals and half-lines.
+fn is_joint(c: char) -> bool {
+    matches!(
+        c,
+        '\u{2502}'
             | '\u{2503}'
             | '\u{2506}'
             | '\u{2507}'
@@ -84,15 +106,70 @@ fn is_rule(line: &str) -> bool {
             | '\u{250c}'..='\u{254b}'
             | '\u{254e}'
             | '\u{254f}'
-            | '\u{2551}'..='\u{257f}' => {}
-            _ => return false,
-        }
-    }
-    horizontals >= RULE_RUN
+            | '\u{2551}'..='\u{257f}'
+    )
 }
 
-/// The content of every rule-bounded region in `pane` that opens with a
-/// prompt marker, marker stripped and whitespace normalized.
+/// Whether a line *is* a horizontal rule, which is how a composer box is
+/// drawn.
+///
+/// The line has to open and close with box-drawing characters and carry a
+/// run of horizontals. Between them it may carry one label: Claude Code
+/// centres the session title in the top border of its composer
+/// (`\u{2500}\u{2500} clear-conversation-state \u{2500}\u{2500}`), which is #36 — requiring every
+/// character to be box-drawing rejected that border, left one rule in the
+/// pane, and identified no composer at all.
+///
+/// One label, not any number of them, and never at either end. That is what
+/// still separates furniture from content: a message body carrying
+/// box-drawn terminal output reaches the composer with its line breaks
+/// intact, and treating one of its lines as furniture would move a region
+/// boundary onto it. Such a line all but always has text outside the run —
+/// `like "\u{2500}\u{2500}\u{2500} Context \u{2500}\u{2500}\u{2500}", dashed variants` opens with a word.
+fn is_rule(line: &str) -> bool {
+    let line = line.trim();
+    let boxed = |c: char| is_horizontal(c) || is_joint(c);
+    if !line.starts_with(boxed) || !line.ends_with(boxed) {
+        return false;
+    }
+    let mut horizontals = 0;
+    let mut labels = 0;
+    let mut in_label = false;
+    for c in line.chars() {
+        if boxed(c) {
+            in_label = false;
+            horizontals += usize::from(is_horizontal(c));
+        } else if !in_label {
+            in_label = true;
+            labels += 1;
+        }
+    }
+    horizontals >= RULE_RUN && labels <= 1
+}
+
+/// Every composer identified in `pane`, each as its own lines, normalized
+/// and stripped of the marker or gutter that identified it.
+///
+/// Lines rather than one joined string because the two decisions want
+/// different views of a composer. Whether it holds our text reads best
+/// across the whole thing, since the composer wraps mid-sentence. Whether
+/// it is *clear* has to read line by line: a box that prints furniture of
+/// its own below the text — OpenCode's model footer — pads a two-word
+/// unsubmitted prompt past the word count that would otherwise call it too
+/// short to classify.
+///
+/// The two layouts here are the two this fleet runs, and neither is a
+/// guess: a rule-bounded box that opens with a known prompt marker, and a
+/// gutter-bounded box at the bottom edge of the pane. A layout matching
+/// neither identifies nothing, which costs a repeat delivery.
+fn composer_regions(pane: &str) -> Vec<Vec<String>> {
+    let lines: Vec<&str> = pane.lines().collect();
+    let mut regions = rule_bounded(&lines);
+    regions.extend(gutter_bounded(&lines));
+    regions
+}
+
+/// Every rule-bounded region that opens with a prompt marker.
 ///
 /// Every such region is returned, not just the last one, and that is the
 /// point. A message body ending in a rule of its own, or a bordered box
@@ -101,8 +178,7 @@ fn is_rule(line: &str) -> bool {
 /// submitted that is sitting on a composer two lines up. A transcript echo
 /// of a submitted prompt cannot be mistaken for one of these, because the
 /// transcript draws no rules around it.
-fn composer_regions(pane: &str) -> Vec<String> {
-    let lines: Vec<&str> = pane.lines().collect();
+fn rule_bounded(lines: &[&str]) -> Vec<Vec<String>> {
     let rules: Vec<usize> = lines
         .iter()
         .enumerate()
@@ -112,11 +188,82 @@ fn composer_regions(pane: &str) -> Vec<String> {
     rules
         .windows(2)
         .filter_map(|w| {
-            let region = normalize(&lines[w[0] + 1..w[1]].join(" "));
-            let marker = MARKERS.iter().find(|m| region.starts_with(**m))?;
-            Some(region[marker.len()..].trim().to_string())
+            let mut region: Vec<String> = lines[w[0] + 1..w[1]]
+                .iter()
+                .map(|l| normalize(l))
+                .filter(|l| !l.is_empty())
+                .collect();
+            let first = region.first()?;
+            let marker = MARKERS.iter().find(|m| first.starts_with(**m))?.len();
+            region[0] = region[0][marker..].trim().to_string();
+            Some(region)
         })
         .collect()
+}
+
+/// One row of a gutter-bounded box, gutter stripped and normalized.
+///
+/// A pane may right-align furniture of its own across the box's rows —
+/// OpenCode wraps a long working directory up the right edge, over the
+/// composer — and a gap of several spaces is what separates the two. The
+/// row is cut at the first such gap.
+///
+/// A row whose *whole* content is right-aligned furniture keeps it instead
+/// of being cut to nothing, and that asymmetry is the safe direction: an
+/// empty row is evidence of a clear composer, and a cut must never
+/// manufacture that evidence out of a row that had something on it. Held
+/// text keeps matching either way, because `is_our_text` reads the region
+/// as one string and our text is what sits left of the gap.
+fn boxed_row(row: &str) -> String {
+    let row = row
+        .trim_start()
+        .trim_start_matches(|c| GUTTERS.contains(&c));
+    let left = normalize(row.split("   ").next().unwrap_or_default());
+    match left.is_empty() {
+        true => normalize(row),
+        false => left,
+    }
+}
+
+/// The composer of an editor that draws a vertical down every row of its
+/// input box instead of a rule above it. OpenCode draws one, and puts a
+/// single horizontal in the whole pane: the bottom edge of that box. One
+/// rule bounds no region, which is the other half of #36 — and no widening
+/// of `is_rule` can reach it, because the rules it would need are not
+/// drawn.
+///
+/// Identification is positional, and it has to be: this layout gives the
+/// composer no marker of its own, and it draws *submitted* messages in the
+/// transcript inside the same gutter. Sitting against the pane's bottom
+/// edge is what separates the composer from those echoes — an echo always
+/// has the rest of the transcript below it.
+fn gutter_bounded(lines: &[&str]) -> Option<Vec<String>> {
+    let gutter = |l: &&str| l.trim_start().starts_with(|c| GUTTERS.contains(&c));
+    let bottom = lines.iter().rposition(|l| is_rule(l))?;
+    let mut top = bottom;
+    while top > 0 && gutter(&lines[top - 1]) {
+        top -= 1;
+    }
+    // A box, not a single bordered line: one gutter line above the bottom
+    // edge is as easily a transcript echo that happens to end there.
+    if bottom - top < 2 {
+        return None;
+    }
+    let mut region: Vec<String> = lines[top..bottom].iter().map(|l| boxed_row(l)).collect();
+    // OpenCode prints the agent and model inside the box, below a blank row
+    // and under anything typed. That is furniture: left in, it pads an
+    // empty composer to three words, and a short unsubmitted prompt beside
+    // it would read as too long to be ours rather than too short to
+    // classify — `Some(false)`, and the batch gone. It is dropped only when
+    // that exact shape is present, because dropping a line that turned out
+    // to be ours is the one error here that could also lose a batch.
+    let footer = region.len() >= 2
+        && !region[region.len() - 1].is_empty()
+        && region[region.len() - 2].is_empty();
+    if footer {
+        region.pop();
+    }
+    Some(region)
 }
 
 /// Whether `content` is a run of `sent` rather than something else on the
@@ -146,8 +293,9 @@ fn is_our_text(content: &str, sent: &str) -> bool {
 /// path: at least one composer was identified, and every identified composer
 /// is either empty or holds text long enough to be recognized as not ours.
 /// Everything else is `None`, including cases that look like nothing at all:
-/// no rules, no marker, a marker we do not know, or content too short to
-/// classify either way.
+/// no composer identified in either layout, a marker we do not know, a
+/// queue hint standing in for the composer's contents, or content too short
+/// to classify either way.
 ///
 /// The caller resolves `None` toward "not submitted". A wrong `Submitted`
 /// drops the batch permanently; a wrong `Unconfirmed` costs a repeat
@@ -161,12 +309,20 @@ fn composer_holds(pane: &str, sent: &str) -> Option<bool> {
         return None;
     }
     let sent = normalize(sent);
-    if regions.iter().any(|c| is_our_text(c, &sent)) {
+    if regions.iter().any(|c| is_our_text(&c.join(" "), &sent)) {
         return Some(true);
     }
+    let lines = || regions.iter().flatten();
+    // A composer showing a queue hint is showing neither our text nor a
+    // clear box: the queue it names may hold our batch or may not, and
+    // nothing in the pane says which.
+    if lines().any(|l| QUEUE_HINTS.contains(&l.as_str())) {
+        return None;
+    }
     // Non-empty but too short to tell ours from a placeholder or a menu.
-    // Idle composers really do carry text that is neither: `\u{276f} Press up to
-    // edit queued messages` is what Claude Code shows over a queue.
+    // Per line, because a composer that draws furniture of its own below
+    // the text would otherwise carry every short line past this on the
+    // strength of the furniture's word count.
     let classifiable = |c: &String| {
         let words = c
             .trim_end_matches(['\u{2026}', '.', ' '])
@@ -174,7 +330,7 @@ fn composer_holds(pane: &str, sent: &str) -> Option<bool> {
             .count();
         words == 0 || words >= OVERLAP_WORDS
     };
-    match regions.iter().all(classifiable) {
+    match lines().all(classifiable) {
         true => Some(false),
         false => None,
     }
@@ -429,6 +585,37 @@ mod tests {
     const EMPTY: &str = include_str!("../tests/fixtures/composer-empty.txt");
     const PLACEHOLDER: &str = include_str!("../tests/fixtures/composer-placeholder.txt");
 
+    /// A Claude Code pane whose composer border carries the session title,
+    /// which is the shape #36 was filed on. Captured from a live lead pane
+    /// with a clear composer.
+    const TITLED: &str = include_str!("../tests/fixtures/composer-titled-rule.txt");
+
+    /// OpenCode panes, captured the same way. The composer is bounded by a
+    /// `\u{2503}` on every row and a single block rule along the bottom, and it
+    /// carries the agent and model on its last row.
+    ///
+    /// `opencode-holds-batch` and `opencode-empty` are one pane before and
+    /// after `\u{2503}`-drawn text was typed into it, and both keep the transcript
+    /// echo of an identical batch that *was* submitted — the echo is drawn
+    /// in the same gutter as the composer, so a locator that finds it
+    /// reports a cleared composer as holding us forever.
+    /// `opencode-wrapped`, `opencode-short` and `opencode-hint` are a
+    /// narrower pane holding a wrapped batch, holding two words, and clear
+    /// under OpenCode's own idle hint. `opencode-live-room` is a working
+    /// lead pane from another room with three echoes above a clear
+    /// composer.
+    const OC_HOLDS: &str = include_str!("../tests/fixtures/opencode-holds-batch.txt");
+    const OC_EMPTY: &str = include_str!("../tests/fixtures/opencode-empty.txt");
+    const OC_WRAPPED: &str = include_str!("../tests/fixtures/opencode-wrapped.txt");
+    const OC_SHORT: &str = include_str!("../tests/fixtures/opencode-short.txt");
+    const OC_HINT: &str = include_str!("../tests/fixtures/opencode-hint.txt");
+    const OC_LIVE: &str = include_str!("../tests/fixtures/opencode-live-room.txt");
+
+    /// What was typed into the OpenCode panes: `RULE` as a real delivery
+    /// carries it, with the sentence that follows it in the preamble.
+    const OC_SENT: &str = "Reply only if you have information others don't \u{2014} don't \
+         acknowledge or repeat. Under 80 words; longer belongs on the issue.";
+
     /// A pane rendered the way herdr's `visible` snapshot returns it: a
     /// transcript, the composer box, then the status footer.
     fn pane(composer: &[&str]) -> String {
@@ -478,12 +665,18 @@ mod tests {
     }
 
     #[test]
-    fn a_real_placeholder_composer_confirms_submission() {
-        // `\u{276f} Press up to edit queued messages` is the hint Claude Code shows
-        // over a queue. Requiring an empty composer would leave every agent
-        // in that state permanently unconfirmable, and the streak would then
-        // skip real batches.
-        assert_eq!(composer_holds(PLACEHOLDER, RULE), Some(false));
+    fn a_real_queue_hint_confirms_nothing() {
+        // `\u{276f} Press up to edit queued messages` is what Claude Code shows over
+        // a queue. This asserted `Some(false)` until #36: five words, none
+        // of them ours, read as a cleared composer. But the hint replaces
+        // the queue's contents rather than describing them, so it is
+        // equally the pane of a batch that never left `herdr agent prompt`
+        // — and `Some(false)` there advances the cursor over it.
+        //
+        // The cost is a repeat delivery per tick while a queue stands, and
+        // `MAX_BATCH_FAILURES` still force-advances after five of those
+        // (#39). That is a bounded, logged skip; this was a silent one.
+        assert_eq!(composer_holds(PLACEHOLDER, RULE), None);
     }
 
     #[test]
@@ -494,6 +687,126 @@ mod tests {
             .collect();
         assert!(!quoting.is_empty(), "fixture lost its rule-quoting line");
         assert_eq!(composer_holds(HOLDS_BATCH, RULE), Some(true));
+    }
+
+    // ---- the layouts this fleet runs ------------------------------------
+
+    #[test]
+    fn every_real_pane_identifies_a_composer() {
+        // #36 in one assertion: none of these identified anything, so every
+        // delivery to them was unconfirmable and the failure threshold
+        // skipped the batch after five tries.
+        for (name, pane) in [
+            ("claude code, titled border", TITLED),
+            ("claude code, plain border", EMPTY),
+            ("opencode, clear", OC_EMPTY),
+            ("opencode, holding a batch", OC_HOLDS),
+            ("opencode, a working lead", OC_LIVE),
+        ] {
+            assert!(
+                !composer_regions(pane).is_empty(),
+                "{name}: no composer identified"
+            );
+        }
+    }
+
+    #[test]
+    fn a_session_title_in_the_composer_border_is_still_a_rule() {
+        let titled = TITLED
+            .lines()
+            .find(|l| l.contains("clear-conversation-state"))
+            .expect("fixture lost its titled border");
+        assert!(is_rule(titled), "{titled:?} not recognized");
+        assert_eq!(composer_holds(TITLED, RULE), Some(false));
+    }
+
+    #[test]
+    fn a_titled_border_over_a_held_batch_is_not_a_confirmation() {
+        // The two halves put together: the real titled border from one pane
+        // above the real held batch of another. Live panes gave each shape
+        // separately, and it is their combination that would drop a batch.
+        let titled = TITLED
+            .lines()
+            .find(|l| l.contains("clear-conversation-state"))
+            .expect("fixture lost its titled border");
+        let mut lines: Vec<&str> = HOLDS_BATCH.lines().collect();
+        let top = lines
+            .iter()
+            .position(|l| is_rule(l))
+            .expect("fixture lost its composer border");
+        lines[top] = titled;
+        assert_eq!(composer_holds(&lines.join("\n"), RULE), Some(true));
+    }
+
+    #[test]
+    fn a_gutter_drawn_composer_holding_a_batch_is_not_confirmed() {
+        assert_eq!(composer_holds(OC_HOLDS, OC_SENT), Some(true));
+    }
+
+    #[test]
+    fn a_gutter_drawn_composer_wrapping_a_batch_still_matches() {
+        assert_eq!(composer_holds(OC_WRAPPED, OC_SENT), Some(true));
+    }
+
+    #[test]
+    fn a_gutter_drawn_composer_too_short_to_classify_is_not_a_confirmation() {
+        // Two words of ours on the composer, beside a model footer that is
+        // five. Counted together they are long enough to be called somebody
+        // else's; the footer is furniture and is not counted.
+        assert_eq!(composer_holds(OC_SHORT, OC_SENT), None);
+    }
+
+    #[test]
+    fn a_clear_gutter_drawn_composer_confirms_submission() {
+        // A working lead pane carrying three transcript echoes of batches
+        // it has already taken, each drawn in the same gutter as the
+        // composer. Confirming here is half the point of the fix: an echo
+        // read as a composer answers `Some(true)` on every tick, and the
+        // unconfirmed streak skips a batch just as surely as a failed
+        // delivery does. One region, and it is the composer.
+        assert_eq!(composer_regions(OC_LIVE).len(), 1);
+        assert_eq!(composer_holds(OC_LIVE, OC_SENT), Some(false));
+    }
+
+    #[test]
+    fn furniture_right_aligned_over_the_composer_costs_confirmation() {
+        // `opencode-empty` is the same clear composer, in a pane whose
+        // working directory is long enough that OpenCode wraps it up the
+        // right edge, across the composer's rows. Its rows are cut at the
+        // gap, but a row that is *only* furniture keeps it rather than
+        // reading as blank — so this costs a repeat delivery instead of
+        // confirming a composer nothing was read from.
+        assert_eq!(composer_regions(OC_EMPTY).len(), 1);
+        assert_eq!(composer_holds(OC_EMPTY, OC_SENT), None);
+    }
+
+    #[test]
+    fn an_idle_hint_over_a_clear_gutter_drawn_composer_confirms_submission() {
+        // OpenCode's own `Ask anything...` hint, unlike a queue hint, is
+        // shown *because* there is nothing to show: no queue stands behind
+        // it, so a batch that reached the pane is not in one.
+        assert_eq!(composer_holds(OC_HINT, OC_SENT), Some(false));
+    }
+
+    #[test]
+    fn no_real_pane_holding_a_batch_reports_it_submitted() {
+        // Requirement stated over the captures rather than over synthetic
+        // perturbations: for every real pane of either kind with our text
+        // unsubmitted on it, the one verdict that advances the cursor is
+        // unreachable. `Some(true)` and `None` both cost a repeat.
+        for (name, pane, sent) in [
+            ("claude code, wrapped", HOLDS_BATCH, RULE),
+            ("opencode", OC_HOLDS, OC_SENT),
+            ("opencode, wrapped", OC_WRAPPED, OC_SENT),
+            ("opencode, two words", OC_SHORT, OC_SENT),
+            ("claude code, queued", PLACEHOLDER, RULE),
+        ] {
+            assert_ne!(
+                composer_holds(pane, sent),
+                Some(false),
+                "{name}: a held batch reported submitted"
+            );
+        }
     }
 
     // ---- nothing identified is never a confirmation ---------------------

--- a/src/herd.rs
+++ b/src/herd.rs
@@ -345,8 +345,8 @@ fn rule_bounded(lines: &[&str]) -> Regions {
 /// double-width character late, by one column per such character, and the
 /// fragment it keeps is exactly the furniture this exists to remove.
 fn box_span(border: &str) -> (usize, usize) {
-    let start = border.chars().take_while(|c| c.is_whitespace()).count();
-    (start, display_width(border.trim_end()))
+    let indent: String = border.chars().take_while(|c| c.is_whitespace()).collect();
+    (display_width(&indent), display_width(border.trim_end()))
 }
 
 /// The cells one character is drawn in, given what the character before it
@@ -1158,6 +1158,21 @@ mod tests {
             assert_eq!(composer_regions(&pane).composers.len(), 1);
             assert_eq!(composer_holds(&pane, OC_SENT), Some(false));
         }
+    }
+
+    #[test]
+    fn both_ends_of_a_box_span_are_measured_in_cells() {
+        // The sibling of the two-metric defect, in the same function: the
+        // indent was counted in characters while the far edge was measured
+        // in cells. Whitespace wider than one cell then makes two boxes at
+        // different columns compare as one, and a rule that is not the
+        // composer's edge pairs with it.
+        let run = "\u{2500}".repeat(RULE_RUN);
+        let wide = format!("\u{3000}{run}");
+        let narrow = format!(" {run}");
+        assert_eq!(display_width("\u{3000}"), 2, "the indents measure alike");
+        assert_eq!(box_span(&wide).0, 2);
+        assert!(!same_box(&wide, &narrow));
     }
 
     #[test]

--- a/src/herd.rs
+++ b/src/herd.rs
@@ -1005,9 +1005,12 @@ mod tests {
         // in a message body — is covered, by
         // `a_rule_inside_a_gutter_row_does_not_box_the_transcript`. A rule
         // drawn on its own line directly beneath an echo's block is not:
-        // inserting one `\u{2579}\u{2580}\u{2580}\u{2580}` line below an echo here yields that echo as
-        // a region holding our batch, and `Some(true)` on a clear composer
-        // for as long as the pane stands.
+        // inserting one line of `\u{2579}\u{2580}\u{2580}\u{2580}...` below an echo here yields that
+        // echo as a region holding our batch, and `Some(true)` on a clear
+        // composer for as long as the pane stands. Elided — as written
+        // those are three horizontals, under `RULE_RUN`, so pasting them
+        // into a test reproduces nothing; the real line is the width of
+        // the pane.
         //
         // Accepted rather than closed. No capture shows a rule beside an
         // echo, every OpenCode pane we have carries exactly one rule, the
@@ -1180,15 +1183,20 @@ mod tests {
     fn both_ends_of_a_box_span_are_measured_in_cells() {
         // The sibling of the two-metric defect, in the same function: the
         // indent was counted in characters while the far edge was measured
-        // in cells. Whitespace wider than one cell then makes two boxes at
-        // different columns compare as one, and a rule that is not the
-        // composer's edge pairs with it.
-        let run = "\u{2500}".repeat(RULE_RUN);
-        let wide = format!("\u{3000}{run}");
-        let narrow = format!(" {run}");
-        assert_eq!(display_width("\u{3000}"), 2, "the indents measure alike");
-        assert_eq!(box_span(&wide).0, 2);
+        // in cells.
+        //
+        // These two rules are drawn at different columns, and counting the
+        // indent is exactly what hides it. An ideographic space is one
+        // character and two cells, so under the old metric both spans came
+        // out (1, 10) — same start, same end — and `same_box` called them
+        // one box, pairing a rule that is not the composer's edge with it.
+        // The pair matters: two rules differing in both fields would fail
+        // `same_box` under either metric and prove nothing.
+        let wide = format!("\u{3000}{}", "\u{2500}".repeat(8));
+        let narrow = format!(" {}", "\u{2500}".repeat(9));
         assert!(!same_box(&wide, &narrow));
+        assert_eq!(box_span(&wide), (2, 10));
+        assert_eq!(box_span(&narrow), (1, 10));
     }
 
     #[test]

--- a/tests/fixtures/composer-below-a-table.txt
+++ b/tests/fixtures/composer-below-a-table.txt
@@ -1,0 +1,59 @@
+ ▐▛███▛█   Claude Code v2.1.246
+▝▜██████▀  Opus 5 (1M context) with medium effort · Claude Max
+  ▝▝ ▝▝    /…/-home-andy--herdr-worktrees-herdr-scuttlebutt-issue-36/8925a21f-c83a-4234-89f0-b3769ac20080/scratchpad/rig
+
+
+❯ Print exactly this markdown table and nothing else, no preamble:
+
+  | id | text |
+  | --- | --- |
+  | 318 | Reply only if you have information others don't — don't acknowledge or repeat. |
+  | 319 | Under 80 words; longer belongs on the issue. |
+
+● ┌─────┬────────────────────────────────────────────────────────────────────────────────┐
+  │ id  │                                      text                                      │
+  ├─────┼────────────────────────────────────────────────────────────────────────────────┤
+  │ 318 │ Reply only if you have information others don't — don't acknowledge or repeat. │
+  ├─────┼────────────────────────────────────────────────────────────────────────────────┤
+  │ 319 │ Under 80 words; longer belongs on the issue.                                   │
+  └─────┴────────────────────────────────────────────────────────────────────────────────┘
+
+✻ Brewed for 2s · done 1:56 PM
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+❯
+──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  andy@apbfw16 /tmp/claude-1000/-home-andy--herdr-worktrees-herdr-scuttlebutt-issue-36/8925a21f-c83a-4234-89f0-b3769ac20080/scr…
+  ⏵⏵ auto mode on (shift+tab to cycle) · ← 2 agents
+                                                                                                                             /rc

--- a/tests/fixtures/composer-below-a-wrapped-table.txt
+++ b/tests/fixtures/composer-below-a-wrapped-table.txt
@@ -1,0 +1,57 @@
+           Claude Code v2.1.246
+ ▐▛███▛█   Opus 5 (1M context)…
+▝▜██████▀  Claude Max
+  ▝▝ ▝▝    /…/scratchpad/rig
+
+
+❯ Output only this table, no
+  other text:
+
+  | id | text |
+  | --- | --- |
+  | 318 | Reply only if you
+  have information others do
+  not |
+
+● ┌─────┬───────────────────┐
+  │ id  │       text        │
+  ├─────┼───────────────────┤
+  │     │ Reply only if you │
+  │ 318 │  have information │
+  │     │  others do not    │
+  └─────┴───────────────────┘
+
+✻ Churned for 1s · done 2:16 PM
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+───────────────────────────────
+❯
+───────────────────────────────
+  andy@apbfw16 /tmp/claude-1…
+  ⏵⏵ auto mode on          ·

--- a/tests/fixtures/composer-titled-rule.txt
+++ b/tests/fixtures/composer-titled-rule.txt
@@ -1,0 +1,60 @@
+  1. Not a one-line is_rule widening. Re-opening the region path re-exposes Some(false) — the only verdict that can drop a batch. herd.rs:168 already documents ❯ Press up to edit queued messages: five words, not our text, → Some(false) → batch dropped while unread. The fix is accepted only with
+     captured-pane evidence that an unsubmitted prompt never yields Some(false) on either kind.
+  2. The dead-sender correlation is a red herring. others filters only on m.from != a.name; liveness is never consulted. Both rooms just went quiet, so nothing landed to restart the streak. Told the IC not to chase it.
+
+  Two notes for you:
+
+  - This is degrading my own delivery channel — I'm at fail_counts: [4, 16], one tick from the skip. Expect gaps in what reaches me until it's fixed.
+  - The daemon runs the installed build, so the fix needs a release plus herdr plugin install andybarilla/herdr-scuttlebutt --ref <tag> from you before it does anything. I'll file the needs-andy line when the release is cut, not now.
+
+  Want me to dispatch ic-debugger on #36? Queue is then #36 in flight, #34 next, #35 gated behind it.
+
+✻ Sautéed for 4m 15s · done 12:44 PM
+
+❯ Reply only if you have information others don't — don't acknowledge or repeat. Under 80 words; longer belongs on the issue.
+  [scuttlebutt] New messages in the room:
+  [#15] ic-herdr-scuttlebutt-32: handoff ready: #32, PR #33. Version bump to 0.2.4 via scripts/release.sh — four files, CI green. Full report already sent to lead-herdr-scuttlebutt.
+
+  Searched for 2 patterns, ran 5 shell commands
+
+● Posted #17 to the room — the diagnosis is information nobody else had. Fifth replay of #15; my cursor is at 4/5, so the next tick force-skips it.
+
+✻ Baked for 34s · done 12:45 PM
+
+❯ yes dispatch that
+
+  Ran 1 shell command
+
+● Wrong repo — it resolved against alare, not mine. Cleaning that up before it confuses anyone.
+
+  Ran 4 shell commands
+
+● The stray .env differs from alare's root one (herdr generated per-worktree values), so I won't delete another project's credentials file myself. Handing that to you:
+
+  Read 1 file
+
+● Now the dispatch, pinned to my repo with --cwd:
+
+  Ran 4 shell commands
+
+● Dispatched.
+
+  - #36 → ic-herdr-scuttlebutt-36 (pane w9C:p1), worktree ~/.herdr/worktrees/herdr-scuttlebutt/issue-36, branch issue-36. Confirmed the brief landed and the pane is working.
+
+  The brief pins it to ic-debugger, hands it the issue, and carries three things the issue alone wouldn't enforce: re-scoping to a kind-aware locator is an acceptable outcome if bounding regions can't keep Some(false) unreachable for an unsubmitted prompt; Refs #36 only, with a git log
+  origin/main..HEAD check before the PR; and a note that the room channel is broken by this very bug, so it hands off via herdr agent prompt and reads its pane back to confirm.
+
+  Two things for you:
+
+  A stray directory needs your rm. My first herdr worktree create resolved against alare, not scuttlebutt, despite my cwd being the scuttlebutt repo — worth knowing as a herdr bug in its own right. I deleted the branch and git has released the worktree, but the directory remains at
+  /home/andy/.herdr/worktrees/alare/issue-36 with a generated .env that differs from alare's root one. I stopped rather than delete another project's credentials file. Logged to needs-andy.jsonl with the exact command; it self-clears once the path is gone. Passing --cwd explicitly worked.
+
+  Queue depth is 2 (#34, #35) against 1 concurrent IC — at target, so no grooming. But #35 is gated on #34, so only #34 is actually startable. If you want a second IC running in parallel, #34 is the one to take.
+
+✻ Cooked for 2m 34s · done 12:50 PM
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── clear-conversation-state ─
+❯
+─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  andy@apbfw16 ~/dev/andybarilla/herdr-scuttlebutt main  [Opus 5 (1M context)] ctx:11%                                                                                                                                                                                                                  /rc
+  ⏵⏵ auto mode on (shift+tab to cycle) · ← 2 agents

--- a/tests/fixtures/opencode-empty.txt
+++ b/tests/fixtures/opencode-empty.txt
@@ -1,0 +1,58 @@
+  ┃                                                                                                                                                                                                                                                                  Selective Reply Instruction
+  ┃  Reply only if you have information others don't — don't acknowledge or repeat. Under 80 words; longer belongs on the issue.
+  ┃  [scuttlebutt] New messages in the room:                                                                                                                                                                                                                         Context
+  ┃  [#1] someone: reply with the single word ok                                                                                                                                                                                                                     9,300 tokens
+  ┃                                                                                                                                                                                                                                                                  2% used
+                                                                                                                                                                                                                                                                     $0.00 spent
+     Thought · 951ms
+                                                                                                                                                                                                                                                                     LSP
+     ok                                                                                                                                                                                                                                                              LSPs will activate as files are read
+
+     ▣  Build · GPT-5.6 Sol · 4.7s
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  ┃                                                                                                                                                                                                                                                                  /tmp/claude-1000/-home-andy--herdr-
+  ┃                                                                                                                                                                                                                                                                  worktrees-herdr-scuttlebutt-issue-36/
+  ┃                                                                                                                                                                                                                                                                  8925a21f-c83a-4234-89f0-b3769ac20080/
+  ┃  Build · GPT-5.6 Sol OpenAI                                                                                                                                                                                                                                      scratchpad/rig
+  ╹▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+   /tmp/claude-1000/-home-andy--herdr-worktrees-herdr-scuttlebutt-issue-36/8925a21f-c83a-4234-89f0-b3769ac20080/scratchpad/rig                                                                                                         9.3K (2%)  ctrl+p commands    • OpenCode 1.18.22

--- a/tests/fixtures/opencode-hint.txt
+++ b/tests/fixtures/opencode-hint.txt
@@ -1,0 +1,36 @@
+                                                                                                                                                                    ▄
+                                                                                                                                   █▀▀█ █▀▀█ █▀▀█ █▀▀▄ █▀▀▀ █▀▀█ █▀▀█ █▀▀█
+                                                                                                                                   █  █ █  █ █▀▀▀ █  █ █    █  █ █  █ █▀▀▀
+                                                                                                                                   ▀▀▀▀ █▀▀▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀
+
+
+                                                                                                                 ┃
+                                                                                                                 ┃  Ask anything... "Fix broken tests"
+                                                                                                                 ┃
+                                                                                                                 ┃  Build · GPT-5.6 Sol OpenAI
+                                                                                                                 ╹▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+                                                                                                                 tab agents  ctrl+p commands
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  /tmp/claude-1000/-home-andy--herdr-worktrees-herdr-scuttlebutt-issue-36/8925a21f-c83a-4234-89f0-b3769ac20080/scratchpad/rig                                                                                                                                                                       1.18.22

--- a/tests/fixtures/opencode-holds-batch.txt
+++ b/tests/fixtures/opencode-holds-batch.txt
@@ -1,0 +1,58 @@
+  ┃                                                                                                                                                                                                                                                                  Selective Reply Instruction
+  ┃  Reply only if you have information others don't — don't acknowledge or repeat. Under 80 words; longer belongs on the issue.
+  ┃  [scuttlebutt] New messages in the room:                                                                                                                                                                                                                         Context
+  ┃  [#1] someone: reply with the single word ok                                                                                                                                                                                                                     9,300 tokens
+  ┃                                                                                                                                                                                                                                                                  2% used
+                                                                                                                                                                                                                                                                     $0.00 spent
+     Thought · 951ms
+                                                                                                                                                                                                                                                                     LSP
+     ok                                                                                                                                                                                                                                                              LSPs will activate as files are read
+
+     ▣  Build · GPT-5.6 Sol · 4.7s
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  ┃                                                                                                                                                                                                                                                                  /tmp/claude-1000/-home-andy--herdr-
+  ┃  Reply only if you have information others don't — don't acknowledge or repeat. Under 80 words; longer belongs on the issue.                                                                                                                                     worktrees-herdr-scuttlebutt-issue-36/
+  ┃                                                                                                                                                                                                                                                                  8925a21f-c83a-4234-89f0-b3769ac20080/
+  ┃  Build · GPT-5.6 Sol OpenAI                                                                                                                                                                                                                                      scratchpad/rig
+  ╹▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+   /tmp/claude-1000/-home-andy--herdr-worktrees-herdr-scuttlebutt-issue-36/8925a21f-c83a-4234-89f0-b3769ac20080/scratchpad/rig                                                                                                         9.3K (2%)  ctrl+p commands    • OpenCode 1.18.22

--- a/tests/fixtures/opencode-live-room.txt
+++ b/tests/fixtures/opencode-live-room.txt
@@ -1,0 +1,59 @@
+  ┃
+  ┃  Reach me with: herdr agent prompt lead-alare \"<handoff or escalation>\". Include model openai/gpt-5.6-sol in the handoff, changed files, commit/PR, exact test output summaries, browser evidence, migration details, and any uncertainty." && herdr agent     Project-lead setup for alare
+  ┃  prompt ic-alare-1076 "$brief"
+  ┃                                                                                                                                                                                                                                                                  Context
+  ┃  {"id":"cli:agent:prompt","result":{"agent":{"agent":"opencode","agent_status":"working","cwd":"/home/andy/.herdr/worktrees/alare/issue-1076","focused":false,"foreground_cwd":"/home/andy/.herdr/worktrees/alare/issue-1076","interactive_ready":true,          60,023 tokens
+  ┃  "name":"ic-alare-1076","pane_id":"w9A:p1","revision":2,"state_change_seq":339,"tab_id":"w9A:t1","terminal_id":"term_659f7a7cf744115","terminal_title":"OC | Alare shared chat room instructions","terminal_title_stripped":"OC | Alare shared chat room         15% used
+  ┃  instructions","workspace_id":"w9A"},"type":"agent_prompted"}}                                                                                                                                                                                                   $0.00 spent
+  ┃
+                                                                                                                                                                                                                                                                     LSP
+     + Thought: Waiting before continuing queue processing · 1.3s                                                                                                                                                                                                    LSPs will activate as files are read
+
+  ┃
+  ┃  $ herdr agent wait ic-alare-1076 --until idle --until done --timeout 120000
+  ┃
+  ┃  {"error":{"code":"timeout","message":"timed out waiting for agent status"},"id":"cli:agent:wait"}
+  ┃
+
+     + Thought: Reporting agent completion and merge cleanup · 1.5s
+
+     In-flight:
+
+     - #1076 — ic-alare-1076 on openai/gpt-5.6-sol, implementing persona generation clock separation and compare-and-set protections.
+
+     Completed:
+
+     - PR #1092 merged as f69b31e0; #1084 closed.
+     - Worktree reclaimed, stale browser servers confirmed stopped, and local main fast-forwarded cleanly.
+     - Queue remains well stocked; no grooming needed.
+
+     ▣  Lead · GPT-5.6 Sol · 4m 12s
+
+  ┃
+  ┃  Reply only if you have information others don't — don't acknowledge or repeat. Under 80 words; longer belongs on the issue.
+  ┃  [scuttlebutt] New messages in the room:
+  ┃  [#376] ic-alare-1084: #1084 is already implemented and handed off: PR #1092 is open, merge-clean, and the board item was moved to In Review before this session’s merge update. No further board-status action is needed unless lead-alare sends review
+  ┃  findings.
+  ┃
+
+     + Thought: Noting PR merged and issue closed · 681ms
+
+     PR #1092 merged as f69b31e0; #1084 is closed and its worktree has been reclaimed.
+
+     ▣  Lead · GPT-5.6 Sol · 3.5s
+
+  ┃
+  ┃  Reply only if you have information others don't — don't acknowledge or repeat. Under 80 words; longer belongs on the issue.
+  ┃  [scuttlebutt] New messages in the room:
+  ┃  [#376] ic-alare-1084: #1084 is already implemented and handed off: PR #1092 is open, merge-clean, and the board item was moved to In Review before this session’s merge update. No further board-status action is needed unless lead-alare sends review
+  ┃  findings.
+  ┃
+
+     ▣  Lead · GPT-5.6 Sol
+
+  ┃
+  ┃
+  ┃
+  ┃  Lead · GPT-5.6 Sol OpenAI                                                                                                                                                                                                                                       ~/dev/alare-leadership/alare:main
+  ╹▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+   ⬝⬝⬝⬝⬝■■■  esc interrupt                                                                                                                                                                                                           60.0K (15%)  ctrl+p commands    • OpenCode 1.18.22

--- a/tests/fixtures/opencode-short.txt
+++ b/tests/fixtures/opencode-short.txt
@@ -1,0 +1,36 @@
+                                                                                                                                                                    ▄
+                                                                                                                                   █▀▀█ █▀▀█ █▀▀█ █▀▀▄ █▀▀▀ █▀▀█ █▀▀█ █▀▀█
+                                                                                                                                   █  █ █  █ █▀▀▀ █  █ █    █  █ █  █ █▀▀▀
+                                                                                                                                   ▀▀▀▀ █▀▀▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀
+
+
+                                                                                                                 ┃
+                                                                                                                 ┃  Reply only
+                                                                                                                 ┃
+                                                                                                                 ┃  Build · GPT-5.6 Sol OpenAI
+                                                                                                                 ╹▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+                                                                                                                 tab agents  ctrl+p commands
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  /tmp/claude-1000/-home-andy--herdr-worktrees-herdr-scuttlebutt-issue-36/8925a21f-c83a-4234-89f0-b3769ac20080/scratchpad/rig                                                                                                                                                                       1.18.22

--- a/tests/fixtures/opencode-wrapped-cwd.txt
+++ b/tests/fixtures/opencode-wrapped-cwd.txt
@@ -1,0 +1,59 @@
+  ┃  [ ] Run repository quality gates and browser smoke test
+  ┃  [ ] Commit changes, open PR, update board, and hand off                                                                                                                                                                                                         Alare shared chat room instructions
+  ┃
+                                                                                                                                                                                                                                                                     Context
+     → Skill "tdd"                                                                                                                                                                                                                                                   48,075 tokens
+                                                                                                                                                                                                                                                                     12% used
+  ┃                                                                                                                                                                                                                                                                  $0.00 spent
+  ┃  $ git status --short --branch && git worktree list --porcelain && gh issue view 1076 --json number,title,body,state,labels,assignees,url
+  ┃                                                                                                                                                                                                                                                                  ▼ LSP
+  ┃  ## issue-1076                                                                                                                                                                                                                                                   • typescript
+  ┃   M apps/api/src/app/market/market.sanitizer.spec.ts                                                                                                                                                                                                             • eslint
+  ┃   M apps/api/src/app/market/market.service.spec.ts                                                                                                                                                                                                               • vue
+  ┃   M apps/api/src/app/market/market.service.ts
+  ┃   M apps/api/src/integration-tests/market-target-market-conflict.int.spec.ts                                                                                                                                                                                     ▼ Todo
+  ┃   M apps/web/src/app/pages/company/MarketPersonaDetailPage.vue                                                                                                                                                                                                   [•] Finish sibling generation-map
+  ┃   M apps/web/src/app/pages/company/MarketTargetMarketPage.vue                                                                                                                                                                                                        web migration and restore
+  ┃   M apps/worker/package.json                                                                                                                                                                                                                                         targeted tests
+  ┃   M apps/worker/src/app/market-marks.service.spec.ts                                                                                                                                                                                                             [ ] Update stale ADR and behavior
+  ┃   M apps/worker/src/app/market-marks.service.ts                                                                                                                                                                                                                      comments
+  ┃  …                                                                                                                                                                                                                                                               [ ] Run targeted and integration
+  ┃                                                                                                                                                                                                                                                                      verification
+  ┃  Click to expand                                                                                                                                                                                                                                                 [ ] Run repository quality gates and
+  ┃                                                                                                                                                                                                                                                                      browser smoke test
+                                                                                                                                                                                                                                                                     [ ] Commit changes, open PR, update
+     → Read ~/.agents/skills/tdd/tests.md                                                                                                                                                                                                                                board, and hand off
+     → Read ~/.agents/skills/tdd/mocking.md
+     → Read ~/.local/share/opencode/tool-output/tool_03f80c8bf001ESkVfUMYqlDyT6 [offset=1, limit=200]
+
+     + Thought: Inspecting generation usage tests · 3.9s
+
+     ✱ Grep "generation|avatarGeneration" in apps/web/src/app/pages/company/MarketTargetMarketPage.spec.ts (100 matches)
+     ✱ Grep "generation|avatarGeneration" in apps/web/src/app/pages/company/MarketPersonaDetailPage.spec.ts (100 matches)
+     → Read libs/shared-types/src/lib/market.ts [offset=1, limit=170]
+     ✱ Grep "generationByPersona|avatarGenerationByPersona|\.generation|avatarGeneration" in apps/web/src/app/pages/company (21 matches)
+
+     + Thought: Examining test fixture variations · 4.1s
+
+     → Read apps/web/src/app/pages/company/MarketTargetMarketPage.spec.ts [offset=130, limit=320]
+     → Read apps/web/src/app/pages/company/MarketPersonaDetailPage.spec.ts [offset=136, limit=410]
+     → Read apps/web/src/app/pages/company/MarketPersonaDetailPage.spec.ts [offset=700, limit=230]
+
+     + Thought: Refactoring helper signature with optional maps · 5.3s
+
+     + Thought: Creating helper wrappers for persona generation mocks · 8ms
+
+     ✱ Grep "avatarGeneration\s*:" in apps/web/src/app/pages/company/MarketPersonaDetailPage.spec.ts
+
+     + Thought: Applying patch changes · 1.1s
+
+     ~ Preparing patch...
+
+     ▣  Ic · GPT-5.6 Sol
+
+  ┃
+  ┃
+  ┃                                                                                                                                                                                                                                                                  ~/.herdr/worktrees/alare/issue-1076:
+  ┃  Ic auto · GPT-5.6 Sol OpenAI                                                                                                                                                                                                                                    issue-1076
+  ╹▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+   ■■■■■■⬝⬝  esc interrupt                                                                                                                                                                                                           48.1K (12%)  ctrl+p commands    • OpenCode 1.18.22

--- a/tests/fixtures/opencode-wrapped.txt
+++ b/tests/fixtures/opencode-wrapped.txt
@@ -1,0 +1,36 @@
+                                                                                                                                                                    ▄
+                                                                                                                                   █▀▀█ █▀▀█ █▀▀█ █▀▀▄ █▀▀▀ █▀▀█ █▀▀█ █▀▀█
+                                                                                                                                   █  █ █  █ █▀▀▀ █  █ █    █  █ █  █ █▀▀▀
+                                                                                                                                   ▀▀▀▀ █▀▀▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀
+
+
+                                                                                                                 ┃
+                                                                                                                 ┃  Reply only if you have information others don't — don't acknowledge
+                                                                                                                 ┃  or repeat. Under 80 words; longer belongs on the issue.
+                                                                                                                 ┃
+                                                                                                                 ┃  Build · GPT-5.6 Sol OpenAI
+                                                                                                                 ╹▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+                                                                                                                 tab agents  ctrl+p commands
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  /tmp/claude-1000/-home-andy--herdr-worktrees-herdr-scuttlebutt-issue-36/8925a21f-c83a-4234-89f0-b3769ac20080/scratchpad/rig                                                                                                                                                                       1.18.22


### PR DESCRIPTION
Refs #36.

`composer_regions` returned zero regions for every pane this fleet runs, so `composer_holds` was `None` on every delivery, nothing was ever confirmed, and `MAX_BATCH_FAILURES` force-advanced the cursor after five tries. Two unrelated layout causes.

**Claude Code** centres the session title in the composer's top border (`── clear-conversation-state ──`). `is_rule` required every character to be box-drawing, so that border was content, one rule was left in the pane, and `windows(2)` yielded nothing. `is_rule` now allows one label between the horizontals and still requires the line to open and close with them, so a message body quoting a rule is still content.

**OpenCode** draws no top border at all: the composer is bounded by a `┃` on every row, with a single horizontal in the whole pane. **No widening of `is_rule` can reach it** — the rules it would need are not drawn. `gutter_bounded` identifies it by position instead: the run of gutter rows sitting against the pane's bottom edge. That is the issue's sanctioned locator path, not a re-scope. Position is what separates the composer from a *submitted* message, which OpenCode echoes into the transcript inside the same gutter.

## The hard constraint, with evidence

Every fixture is a real pane, `herdr agent read --source visible --format text`, verbatim but for trailing spaces. `no_real_pane_holding_a_batch_reports_it_submitted` states the requirement directly over them:

| pane | verdict |
|---|---|
| Claude Code, batch wrapped on the composer | `Some(true)` |
| Claude Code, `❯ Press up to edit queued messages` | `None` |
| Claude Code, titled border over a held batch | `Some(true)` |
| OpenCode, batch on the composer | `Some(true)` |
| OpenCode, batch wrapped across rows | `Some(true)` |
| OpenCode, two words on the composer | `None` |

`Some(false)` stays reachable where it should be — `a_clear_gutter_drawn_composer_confirms_submission` and `a_real_pane_with_an_empty_composer_confirms_submission` — because a permanent `Some(true)` skips a batch through `unconfirmed_streak` just as surely as a permanent `None` does.

Two things inside the OpenCode box are furniture, and both would otherwise pad a short unsubmitted prompt past the word count that calls it too short to classify — `Some(false)`, and the batch gone. The model footer is dropped when its shape is present. The pane's own right-aligned furniture (a long working directory wrapped up the right margin, across the box's rows) is clipped off by the columns of the bottom edge that closes the box: nothing the composer draws lies outside its own box, so the clip cannot empty a row that had our text on it.

## Found by sweeping the fleet, not the fixtures

The second commit exists because the locator was run over every live pane rather than only over the captures. `ic-alare-1076` was not read: its working directory wraps across the composer's rows, and those fragments are one word each, so the pane is unconfirmable for as long as its cwd is that long — #36's shape again. It is now a fixture (`opencode-wrapped-cwd.txt`). All five live panes — two OpenCode, three Claude Code, across two rooms — identify exactly one composer and confirm their clear composers.

## One behaviour deliberately inverted

`a_real_placeholder_composer_confirms_submission` asserted `composer_holds(PLACEHOLDER, RULE) == Some(false)` and was green. It is now `a_real_queue_hint_confirms_nothing`, asserting `None`. The hint replaces the queue's contents rather than describing them, so the same pane is equally that of a batch which never left `herdr agent prompt` — and `Some(false)` advances the cursor over it. The old comment's worry was right about the cost: an agent working a standing queue is unconfirmable while it stands. The hint is matched on a fragment, not the whole line, because a count or an appended key hint would stop an exact match firing and fall back to `Some(false)` silently.

## What is left, and what gates it

#36's severity has a residual half, filed as **#39** and labelled `ready-for-human`: `MAX_BATCH_FAILURES` still force-advances the cursor over an unconfirmed delivery, so five consecutive `None`s still drop a batch. Removing the threshold trades a dropped batch for an unbounded redelivery loop, so it is a decision rather than a fix.

No version bump here. The daemon runs the installed build, so this needs a release and `herdr plugin install andybarilla/herdr-scuttlebutt --ref <tag>` before it takes effect.

## Review round 2 — four HARD findings closed

All four reproduced, all four fixed, each pinned by a test that fails without its fix. The eight mutations named in review were run against the result and every one fails.

| finding | fix | pinned by |
|---|---|---|
| a rule inside the batch splits the composer and the marker-less half was discarded | regions split into `composers` and `others`; `others` can say our text is still there, never that a composer is clear. `is_rule` measures its run per run rather than summed, so a short centred label between stubs stays content | `a_rule_inside_the_batch_does_not_hide_the_half_without_the_marker`, `a_short_centred_label_between_stubs_is_not_a_rule`, `a_line_with_two_labels_is_not_a_rule` |
| `gutter_bounded` took the last rule anywhere, not the bottom edge, and one box replaced the composer | every gutter box closed by a rule is returned; the comment now says what the code does | `an_overlay_below_a_gutter_composer_does_not_hide_the_batch`, `a_gutter_composer_is_found_above_the_bottom_of_the_pane`, `a_single_gutter_row_above_a_rule_is_not_a_composer` |
| clipping counted characters, so a double-width character pulled a column of right-margin furniture into a row | columns are display cells; `boxed_row` also trims a row's own indent before stripping its gutter | `a_double_width_character_does_not_pull_furniture_into_a_row` |
| the footer pop fired on `["", "", "Reply only"]` and ate our prompt | pop removed entirely — per-row classification already does its job | `a_gutter_box_without_a_footer_still_holds_what_is_in_it` |

Two claims in the review were checked and are worth recording. The titled border is **right-aligned**, not centred — 274 horizontals, the title, then one — so requiring `RULE_RUN` on both sides of a label rejects the real border. The measured-per-run bound is what survives the data. And three OpenCode captures put their box a third of the way down the pane, so "bottom edge" was wrong as well as unpinned; "closed by a rule" is the actual discriminator and is now what both the code and the comment say.

The rationale comment on `a_clear_gutter_drawn_composer_confirms_submission` was false and is corrected: echoes are excluded because no rule is drawn beneath them, which is weaker than it sounds, and keeping every box is what makes it survivable.

Re-swept all five live panes with the final code: each identifies exactly one composer. `cargo test` 260 passed / 0 failed, fmt and clippy clean.

## Review round 3 — HARD A and HARD B closed

**HARD A reproduces on a real pane, and `>` is not the whole of it.** A Claude Code pane asked to render a markdown table draws rules of its own, and the region between two of them carries a row beginning with `DELIVERY_RULE` — which opens every batch we send, so it matches all of them, forever. That region needed no marker: `others` voted `Some(true)` on a clear composer on every tick. The pane is checked in as `composer-below-a-table.txt` and the assertion is `Some(false)`; before the fix it is `Some(true)`.

The fix is a box test, not a marker test. **A region counts only when its two rules could be the two edges of one box — same column, same width in cells.** A table's border is not the composer's width, so the transcript is out. `others` is narrowed to the regions beside a composer, the one place a composer's own content can be.

`>` is dropped from `MARKERS` anyway, on its own merits: no agent this fleet runs opens its composer with one, and it is what markdown opens a blockquote with.

**HARD B** is closed twice over. A pasted rule of a different width means no two rules in the pane can be one box's edges, so nothing is identified. A pasted rule at exactly the box's width splits it into two regions that both look like its own — and `Some(false)` is now unreachable while any `others` region stands, because which half is the composer's is precisely what cannot be told apart.

**`box_span` in display cells is now pinned** (`a_closing_rule_with_a_wide_label_measures_its_box_in_cells`), as is `boxed_row`'s indent trim.

Fifteen mutations, every one red: `labels <= 2`; summing horizontals instead of measuring the run; discarding `others`; keeping `others` anywhere; keeping only the last gutter box; `bottom - top < 1`; clipping by chars; `box_span` in chars; dropping the indent trim; classifying the region joined; exact-matching the queue hint; restoring the footer pop; restoring `>`; `same_box` always true; and removing the split-box guard.

### On the fixture gap

`others` is now reachable only when a rule is pasted into the composer at exactly the box's width and column. No real pane does that, and I did not manufacture a capture to pretend otherwise — the real fixture that matters is `composer-below-a-table.txt`, which pins the other half: a real pane's extra rules do **not** become regions. With this round's change it yields 1 composer and 0 others.

The "6 others regions" in the round-2 report came from a live sweep of the lead's own pane, which had a rendered table in its transcript at that moment; that pane has since scrolled. Rather than cite a capture nobody else could reproduce, I reproduced the shape deliberately and checked it in.

### One behaviour change worth knowing

A rule pasted into the batch at a width the box does not share now identifies nothing rather than holding us — `None` where it used to be `Some(true)`. Both are unconfirmed to the daemon and cost the same repeat; only the logged reason differs.

All six live panes re-swept with the final code: 1 composer, 0 others, `Some(false)` each. `cargo test` 260 passed / 0 failed.

## Review round 4 — the gutter's exemption closed

**HARD 1 reproduced on a real pane before touching anything.** A Claude Code pane narrow enough to wrap a table cell puts three light-`│` rows straight above the table's own bottom rule. That is a gutter box by every test `gutter_bounded` applies, and `gutter_bounded` has no second rule for `same_box` to measure — so the cell, quoting `DELIVERY_RULE`, was a composer holding our batch on every tick. `composers=2`, `Some(true)`, forever. Checked in as `composer-below-a-wrapped-table.txt`.

The light vertical is dropped from `GUTTERS`. OpenCode draws the heavy one; nothing this fleet runs draws the light one; an editor that did would identify nothing, which costs a repeat. Same defect as a bare `>` in `MARKERS`, one function over.

**HARD 2 — the doc was falsified by its own fixture and I confirmed it.** `composer-below-a-table`'s separators all span `(2, 90)` and do form boxes. What excludes them is that none sits beside a composer; matching edges do different work, excluding the region between the table and the composer that would otherwise veto forever. Mutating adjacency off gives `Some(true)`; mutating `same_box` off gives `None`. The comment now names both jobs.

**The column half of `same_box` is pinned**, and it needed a rule that *ends* where the composer's border ends rather than one of the same length — comparing lengths alone was already caught by `box_span` returning absolute columns.

**Emoji-presentation width is fixed, not documented away.** This round made identification depend on two rules measuring equal, so `display_width` now promotes a `U+FE0F` sequence to the two cells a terminal draws. A title carrying one would otherwise have identified no composer for as long as the session kept it.

Eighteen mutations, every one red.

### The `others` path — decision

**Kept, and no longer described as unreachable.** Reaching one takes a rule inside the composer drawn at the box's own column *and* width; a real composer indents what it holds, so a pasted rule lands a column or two in and matches nothing. That is written into the type's doc rather than left implied.

It stays because nothing else stands between that shape and a dropped batch — delete it and round 3's `a_bare_marker_beside_a_split_box_does_not_confirm` goes back to `Some(false)` — because what it costs when it fires is a repeat rather than a drop, and because every layout this has been wrong about so far was one nobody had captured either. I did not manufacture a fixture to dress a synthetic test as a real one.

### Test coverage restored

`a_batch_ending_in_a_rule` and `a_one_character_tail` now assert the actual value with `assert_eq!` rather than `assert_ne!(Some(false))`, and the titled body rule `───── Context ─────` is covered again — it is not furniture at all, so the composer is never split and still reads as holding us.

All seven live panes re-swept: 1 composer, 0 others, `Some(false)` each. `cargo test` 260 passed / 0 failed. Merges clean onto `243e23d`.

## Review round 5 — two metrics, and a gutter row read as a rule

**HARD 1.** `box_span` promoted an emoji-presentation sequence to the two cells a terminal draws it in and `boxed_row` did not — two metrics over one coordinate space. The clip ran a cell late per sequence and kept the start of the working directory wrapped up the right margin; beside two words of ours that is a third word, and a third word classifies. On the real wrapped-cwd pane with a prompt still on the composer: `Some(false)`.

`cell_width` is now the only place a character is measured. Round 4's double-width test could not have caught this — `🎉` is two cells under *both* metrics, so it never told them apart. The new test asserts the metrics disagree about its character before it asserts anything else.

**HARD 2.** `is_joint` carries the heavy gutter, so `┃  ├────┤` — a table separator inside a message OpenCode has already taken — was a rule, and `gutter_bounded` walks up from every rule and boxed the echo above as a composer holding the batch it quotes. Same class as round 4's light gutter, reached through the heavy one.

Two guards, each pinned by a shape only it catches: **a gutter opens a row of a box and never that box's edge**, and **a gap between two pieces of furniture on one row is not a title**. That also falsifies what `a_clear_gutter_drawn_composer_confirms_submission` claimed — "no rule is drawn beneath an echo" is untrue of any message body carrying a table or a `---` — and the comment now states the narrower thing that does hold.

A variation selector with nothing to promote adds nothing, rather than two.

Twenty-two mutations, every one red with a distinct killer. All six live panes: 1 composer, 0 others, `Some(false)`. `cargo test` 260 passed / 0 failed.

## Round 6 — the two gate items, plus one sibling found by grepping the class

**The comment on `a_clear_gutter_drawn_composer_confirms_submission` now says the thing.** What excludes the echoes in `opencode-live-room` is that no rule is drawn beneath any of them — a property of that pane, not a guarantee. A rule inside an echo's own gutter row is covered; a rule on its own line directly beneath an echo's block is not. I reproduced that before writing the sentence: inserting one `╹▀▀▀` line yields the echo as a region holding our batch and `Some(true)` on a clear composer, permanently. Accepted rather than closed, and the comment says so — no capture shows one, every OpenCode pane carries exactly one rule, and the cost is the bounded `Some(true)` that #42 covers, not a drop.

It also no longer credits keeping every box, which does nothing here: `composer_holds` returns on the first region matching our text, so which boxes were kept never enters into it. That serves the opposite case — an overlay below a real composer.

**The cross-product is checked in.** Tables were tested only against a clear composer and held batches only against table-free panes, so the untested shape was the one where a moved boundary costs a *batch* rather than an agent. Both table panes now get their composer rows replaced with the batch. The test is not vacuous: `same_box`, the adjacency filter and the light gutter each break it.

**One sibling, found by taking #42's lesson literally.** After fixing "two metrics over one coordinate space" I grepped this file for the class rather than the instance, and `box_span` was still counting its indent in **characters** while measuring its far edge in **cells** — one line above where the reviewer found it, in a function two review passes had already been through. Whitespace wider than one cell makes two boxes at different columns compare as one. Fixed in `b2fcf0f` with a test that fails without it.

`cell_width`'s doc records that a second consecutive variation selector over-counts, which clips early — the safe direction — and is left alone.

`cargo test` 260 passed / 0 failed.

### Two things this PR does not claim

**`b2fcf0f` fixed no outage.** Every captured fixture indents with ASCII spaces, so measuring the indent in cells rather than characters changes no observed behaviour on any of them. It is correctly-directed hardening against a pane indented with whitespace wider than one cell, found by grepping the class rather than by anything failing.

**The elided rule in the comment on `a_clear_gutter_drawn_composer_confirms_submission`** is written `╹▀▀▀...` and carries three horizontals — under `RULE_RUN`, so pasting it into a test reproduces nothing. The real line is the width of the pane. It is marked as elided in the source.

### One habit worth recording

Four assertions on this branch read stronger than they were, and the last of them — `!same_box(&wide, &narrow)` with a pair differing in both fields — held under the reverted code while the test as a whole still failed. A test that fails without the fix is not the same as a test whose every assertion discriminates. Only the second kind survives someone else's refactor, and each of the four was found by mutating rather than by reading.

## Verification

`cargo fmt --check`, `cargo clippy --all-targets` clean, `cargo test` 260 passed / 0 failed. The new assertions were run against pre-fix `herd.rs` first: `claude code, titled border: no composer identified` and `queue hint` both failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ThB52fa2BPJuSTJ5sVpjf3
