### PR TITLE
Switch which room a chat pane is viewing

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,11 @@ description = "Scuttlebutt: chat tab"
 | `andybarilla.scuttlebutt.daemon-stop` | Stop it |
 | `andybarilla.scuttlebutt.daemon-status` | Report whether it is running |
 
-In the chat pane, `Enter` posts, `Up`/`Down` scroll, and `Esc` or `Ctrl-C`
-leaves.
+In the chat pane, `Enter` posts, `Up`/`Down` scroll, `Ctrl-K` opens the room
+picker, and `Esc` or `Ctrl-C` leaves. With the picker open, `Esc` closes it
+instead: type to filter, `Up`/`Down` to move, `Enter` to switch. Posts go to
+the room you are viewing, and the input line names it when it is not the room
+the pane opened in.
 
 ## Use
 
@@ -103,6 +106,11 @@ several organizations, or to group repositories that have no remote:
 alare       = ["~/dev/alare", "~/.herdr/worktrees/alare"]
 printersrow = ["~/dev/printersrow"]
 ```
+
+A room does not have to be configured to exist: one derived from a repository
+`origin`, or one whose group has since left the config and survives as a log on
+disk, is a room like any other. `scuttlebutt rooms` lists all of them, and the
+chat pane's picker offers them.
 
 Names must match `[a-z0-9][a-z0-9_-]*`; they become directory names. Longest
 prefix wins, and prefixes match on path-segment boundaries, so `~/dev/alare`

--- a/README.md
+++ b/README.md
@@ -109,8 +109,10 @@ printersrow = ["~/dev/printersrow"]
 
 A room does not have to be configured to exist: one derived from a repository
 `origin`, or one whose group has since left the config and survives as a log on
-disk, is a room like any other. `scuttlebutt rooms` lists all of them, and the
-chat pane's picker offers them.
+disk, is a room like any other. `scuttlebutt rooms` lists every room something
+vouches for — an agent standing in it, the config, or a log on disk — and the
+chat pane's picker offers those. A group with none of the three is still legal
+and simply has nothing to list yet.
 
 Names must match `[a-z0-9][a-z0-9_-]*`; they become directory names. Longest
 prefix wins, and prefixes match on path-segment boundaries, so `~/dev/alare`

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,5 @@
 use crate::git_org::OrgCache;
-use crate::groups::{self, Grouping};
+use crate::groups::{self, CurrentRoom, Grouping};
 use crate::herd::{AgentInfo, HerdControl};
 use crate::log_store::{self, Message};
 use anyhow::{bail, Result};
@@ -9,12 +9,21 @@ use std::path::Path;
 /// origin organization. Refusing an unresolvable cwd under an active config
 /// rather than falling back to a default room is deliberate: a silent fallback
 /// would show one group's traffic to a caller nothing places there.
-pub fn resolve_group(
+/// The room a caller lands in, as the three-state room a chat pane holds.
+///
+/// `Broken` still bails: `groups::rooms` lists nothing there, so the picker
+/// this feeds could only offer rooms swept off disk — every company's — from
+/// a config we could not parse.
+///
+/// An active config that matches nothing is `NoneSelected` rather than an
+/// error. Only a chat pane can use that state, which is why `resolve_group`
+/// below still refuses it for every one-shot command.
+pub fn resolve_room(
     explicit: Option<&str>,
     cwd: &Path,
     grouping: &Grouping,
     orgs: &mut OrgCache,
-) -> Result<Option<String>> {
+) -> Result<CurrentRoom> {
     if let Grouping::Broken(msg) = grouping {
         bail!("groups config is unusable: {msg}");
     }
@@ -29,13 +38,30 @@ pub fn resolve_group(
         if !groups::valid_group_name(g) {
             bail!("invalid group name {g:?} (allowed: [a-z0-9][a-z0-9_-]*)");
         }
-        return Ok(Some(g.to_string()));
+        return Ok(CurrentRoom::Named(g.to_string()));
     }
-    match groups::resolve(cwd, grouping, orgs) {
-        Some(g) => Ok(Some(g)),
+    Ok(match groups::resolve(cwd, grouping, orgs) {
+        Some(g) => CurrentRoom::Named(g),
         // No config and no repo is v1's single shared room, not an error.
-        None if matches!(grouping, Grouping::Inactive) => Ok(None),
-        None => bail!(
+        None if matches!(grouping, Grouping::Inactive) => CurrentRoom::Ungrouped,
+        None => CurrentRoom::NoneSelected,
+    })
+}
+
+/// The group a one-shot command operates on. Everything but the chat pane
+/// needs a room right now, so the state a pane opens a picker in is an error
+/// here. Delegates to `resolve_room` so the precedence — an explicit name,
+/// then a configured prefix, then the repo's origin — is written once.
+pub fn resolve_group(
+    explicit: Option<&str>,
+    cwd: &Path,
+    grouping: &Grouping,
+    orgs: &mut OrgCache,
+) -> Result<Option<String>> {
+    match resolve_room(explicit, cwd, grouping, orgs)? {
+        CurrentRoom::Named(g) => Ok(Some(g)),
+        CurrentRoom::Ungrouped => Ok(None),
+        CurrentRoom::NoneSelected => bail!(
             "cwd {} matches no group and its repo has no origin remote; \
              add a prefix for it to groups.toml or pass --group",
             cwd.display()
@@ -425,6 +451,58 @@ mod tests {
             &mut orgs(fake_org)
         )
         .is_err());
+    }
+
+    #[test]
+    fn a_chat_pane_opens_with_no_room_where_a_command_would_be_refused() {
+        // The same cwd `ungrouped_cwd_outside_a_repo_is_refused_not_defaulted`
+        // rejects. A pane can offer a picker there; a one-shot command cannot.
+        let room = resolve_room(
+            None,
+            Path::new("/tmp/scratch"),
+            &active(),
+            &mut orgs(no_org),
+        )
+        .unwrap();
+        assert_eq!(room, CurrentRoom::NoneSelected);
+    }
+
+    #[test]
+    fn no_config_and_no_repo_is_the_shared_room_not_an_absent_one() {
+        let room = resolve_room(
+            None,
+            Path::new("/tmp/scratch"),
+            &Grouping::Inactive,
+            &mut orgs(no_org),
+        )
+        .unwrap();
+        assert_eq!(room, CurrentRoom::Ungrouped);
+    }
+
+    #[test]
+    fn a_broken_config_is_refused_a_room_even_for_a_pane() {
+        // `groups::rooms` lists nothing under `Broken`, so the picker this
+        // would open could only offer rooms swept off disk — every
+        // company's — from a config we could not parse.
+        assert!(resolve_room(
+            None,
+            Path::new("/w/alare"),
+            &Grouping::Broken("bad".into()),
+            &mut orgs(fake_org)
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn an_explicit_group_names_the_room_for_a_pane_too() {
+        let room = resolve_room(
+            Some("acme"),
+            Path::new("/tmp/scratch"),
+            &active(),
+            &mut orgs(no_org),
+        )
+        .unwrap();
+        assert_eq!(room, CurrentRoom::Named("acme".into()));
     }
 
     fn agents() -> Vec<AgentInfo> {

--- a/src/groups.rs
+++ b/src/groups.rs
@@ -243,6 +243,59 @@ impl Room {
     }
 }
 
+/// The room a chat pane is currently viewing.
+///
+/// Three states rather than `Option<String>`, which conflates the last two:
+/// the ungrouped room is a real room with a real directory that can be read
+/// and posted to, while `NoneSelected` is a pane whose cwd resolved to no
+/// group and which has nowhere to post until a human picks a room. Collapsed
+/// into one `None`, a draft map and `title_for` would disagree about that
+/// pane the first time anyone ran without a `groups.toml`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
+pub enum CurrentRoom {
+    Named(String),
+    /// `session_dir()` itself — v1's single shared room, offered only when
+    /// grouping is `Inactive`.
+    Ungrouped,
+    #[default]
+    NoneSelected,
+}
+
+impl CurrentRoom {
+    /// The `Option<&str>` group that `room_dir`, `title_for` and
+    /// `visible_agents` all take, or `None` when no room is selected. The
+    /// nesting is the point: the inner `None` is the ungrouped room, so a
+    /// caller has to deal with "nothing selected" before it can ask which
+    /// group it is looking at.
+    pub fn selected(&self) -> Option<Option<&str>> {
+        match self {
+            CurrentRoom::Named(n) => Some(Some(n.as_str())),
+            CurrentRoom::Ungrouped => Some(None),
+            CurrentRoom::NoneSelected => None,
+        }
+    }
+
+    /// How this room is written wherever a room is named to a human: the
+    /// picker rows, the substring filter that searches them, and the pane
+    /// title all use this, so what you can see is what you can type.
+    pub fn label(&self) -> &str {
+        match self {
+            CurrentRoom::Named(n) => n.as_str(),
+            CurrentRoom::Ungrouped => "(ungrouped)",
+            CurrentRoom::NoneSelected => "no room selected",
+        }
+    }
+}
+
+impl From<&Room> for CurrentRoom {
+    fn from(r: &Room) -> Self {
+        match &r.name {
+            Some(n) => CurrentRoom::Named(n.clone()),
+            None => CurrentRoom::Ungrouped,
+        }
+    }
+}
+
 /// Whether a room directory holds a `room.jsonl` with anything in it.
 /// Emptiness is the filter that matters: `paths::room_dir` calls
 /// `create_dir_all` before the first post, so one mistyped `--group` leaves a
@@ -957,7 +1010,9 @@ mod tests {
     fn the_order_of_a_rooms_sources_matches_the_order_rooms_are_sorted_in() {
         // the invariant that keeps a label and a sort position honest: for
         // any two rooms, the one whose primary source comes first in
-        // provenance order sorts first
+        // provenance order sorts first. Written out longhand on purpose —
+        // asserting the list is sorted by its own key would hold however
+        // that key was declared, and it is the declared order that skews.
         let session = tempfile::tempdir().unwrap();
         write_room(session.path(), Some("zeta"), "{}\n");
         let g = Grouping::Active(rules(&[("busy", &["/w/busy"]), ("quiet", &["/w/quiet"])]));
@@ -975,8 +1030,5 @@ mod tests {
             primaries,
             vec![Source::Agents, Source::Config, Source::History]
         );
-        let mut sorted = primaries.clone();
-        sorted.sort();
-        assert_eq!(primaries, sorted, "list order must follow primary source");
     }
 }

--- a/src/groups.rs
+++ b/src/groups.rs
@@ -382,10 +382,11 @@ pub fn rooms(
         }
     }
     // The ungrouped room is `session_dir()` itself, so it has no entry in the
-    // sweep above. Under an active config it receives nothing and
-    // `resolve_group` can never return `None`, so its history is the record
-    // of a room that can no longer be posted to; offering it would invite
-    // posting into a dead room.
+    // sweep above. Under an active config it receives nothing and neither
+    // `resolve_group` nor `resolve_room` can land in it, so its history is
+    // the record of a room that can no longer be posted to; offering it —
+    // to the chat pane's picker above all, which posts wherever it is
+    // pointed — would invite posting into a dead room.
     if matches!(grouping, Grouping::Inactive) && has_history(session_dir) {
         entry_for(&mut found, None).history = true;
     }

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 pub fn session_key() -> String {
     match std::env::var("HERDR_SOCKET_PATH") {
@@ -33,13 +33,27 @@ pub fn session_dir() -> Result<PathBuf> {
     Ok(dir)
 }
 
-/// The directory holding one room's `room.jsonl` and `state.json`. `None` is
-/// the ungrouped layout (grouping inactive) and keeps v1's paths exactly.
+/// Where one room's `room.jsonl` and `state.json` live under `session`.
+/// `None` is the ungrouped layout (grouping inactive) and keeps v1's paths
+/// exactly.
+///
+/// Pure, and deliberately so: `room_dir` below creates the directory, which
+/// a caller that only wants to *look* at a room must not do. Sweeping every
+/// room's log length on each picker open would otherwise conjure a
+/// directory per room per open — the empty-directory-forever problem
+/// `groups::has_history` exists to filter out.
+pub fn room_dir_in(session: &Path, group: Option<&str>) -> PathBuf {
+    match group {
+        Some(g) => session.join(g),
+        None => session.to_path_buf(),
+    }
+}
+
+/// The directory holding one room's `room.jsonl` and `state.json`, created
+/// if it does not exist. For a room about to be written to or read as the
+/// current room; use `room_dir_in` to merely name one.
 pub fn room_dir(group: Option<&str>) -> Result<PathBuf> {
-    let dir = match group {
-        Some(g) => session_dir()?.join(g),
-        None => session_dir()?,
-    };
+    let dir = room_dir_in(&session_dir()?, group);
     std::fs::create_dir_all(&dir)?;
     Ok(dir)
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -75,9 +75,14 @@ pub struct App {
     pub members: Vec<AgentInfo>,
     pub scroll_from_bottom: u16,
     pub quit: bool,
-    /// Last post failure, surfaced in the input-line title. A transient write
-    /// failure must not tear the chat pane down.
-    pub post_error: Option<String>,
+    /// The last failed action, surfaced in the input-line title. A transient
+    /// failure must not tear the chat pane down — neither a write nor a
+    /// switch.
+    ///
+    /// Each writer stores a message describing its own action, because two
+    /// actions land here and a fixed "post failed" prefix would report a
+    /// failed switch as a post nobody attempted.
+    pub last_error: Option<String>,
     /// Message-pane title, always naming the room being viewed — a group,
     /// the ungrouped room, or none selected. It is half the safeguard
     /// against posting into the wrong company's room; the input line's
@@ -469,16 +474,24 @@ fn switch_room(
     // into another company's room.
     let loaded = match target.selected() {
         Some(group) => {
-            let dir = crate::paths::room_dir(group)?;
+            let dir = crate::paths::room_dir_in(session_dir, group);
             // A clean read of the whole file, never `should_reseed`: that
             // asks whether *this* room's log was truncated, and it would be
             // comparing this room's cursor against another room's last id.
+            // A room with no directory yet reads as empty rather than
+            // failing, which is why the read can precede the create below.
             let messages = log_store::read_since(&dir, 0)?;
             // A failed listing is not a failed switch: `scoped_members`
             // returns `None` for it, and an empty roster beside the new
             // room's title is honest, where the old room's names would not
             // be.
             let members = scoped_members(herd, group, grouping, orgs).unwrap_or_default();
+            // Created only once the room is certain to open, so a switch
+            // that fails leaves no empty directory behind — the litter
+            // `groups::has_history` exists to sweep out of listings.
+            // `room_dir` would have created it before the read could fail,
+            // and reaches `base_dir`, which spawns a subprocess per switch.
+            std::fs::create_dir_all(&dir)?;
             Some((dir, messages, members))
         }
         None => None,
@@ -504,7 +517,7 @@ fn switch_room(
     }
     app.scroll_from_bottom = 0;
     // A write failure belonged to the room it was attempted in.
-    app.post_error = None;
+    app.last_error = None;
 
     match loaded {
         Some((dir, messages, members)) => {
@@ -595,9 +608,9 @@ pub fn run(group: Option<&str>) -> Result<()> {
                                 // selected, so a pane with none never reaches
                                 // an append with no directory.
                                 if let Some(dir) = &app.dir {
-                                    app.post_error = match log_store::append(dir, "human", &text) {
+                                    app.last_error = match log_store::append(dir, "human", &text) {
                                         Ok(_) => None,
-                                        Err(e) => Some(e.to_string()),
+                                        Err(e) => Some(format!("post failed: {e}")),
                                     };
                                 }
                             }
@@ -633,7 +646,7 @@ pub fn run(group: Option<&str>) -> Result<()> {
                                     // the room it was in, with every draft
                                     // where it was left.
                                     Err(e) => {
-                                        app.post_error =
+                                        app.last_error =
                                             Some(format!("could not open that room: {e}"))
                                     }
                                 }
@@ -717,12 +730,14 @@ fn draw(f: &mut ratatui::Frame, app: &App) {
     // and the border stays away-yellow rather than error-red: a reader who
     // has learned that yellow means "not your room" must not lose it to a
     // transient write error.
-    let (input_title, border) = match (&app.post_error, app.room.selected().is_some(), away) {
-        (Some(e), _, true) => (
-            format!(" → {} · post failed: {e} ", app.room.label()),
-            Color::Yellow,
-        ),
-        (Some(e), _, false) => (format!(" post failed: {e} "), Color::Red),
+    let (input_title, border) = match (&app.last_error, app.room.selected().is_some(), away) {
+        // A pane with no room selected keeps its one affordance whatever
+        // else has failed. Ctrl-K is the only way out of a state the pane
+        // cannot leave on its own — the state #35 exists to rescue — so an
+        // error that displaced the hint would make the pane dead again.
+        (Some(e), false, _) => (format!(" {e} — Ctrl-K to pick a room "), Color::Red),
+        (Some(e), _, true) => (format!(" → {} · {e} ", app.room.label()), Color::Yellow),
+        (Some(e), _, false) => (format!(" {e} "), Color::Red),
         (None, false, _) => (
             " no room selected — Ctrl-K to pick a room ".to_string(),
             Color::DarkGray,
@@ -785,8 +800,15 @@ fn draw_picker(f: &mut ratatui::Frame, picker: &PickerState) {
                         if r.unread { "● " } else { "  " },
                         Style::default().fg(Color::Yellow),
                     ),
+                    // Padded by display cells, not chars, like every other
+                    // width in this file: a CJK room name is twice as wide
+                    // as it is long and would push the column out of line.
                     Span::styled(
-                        format!("{:<20}", r.room.label()),
+                        format!(
+                            "{}{}",
+                            r.room.label(),
+                            " ".repeat(20usize.saturating_sub(display_width(r.room.label())))
+                        ),
                         Style::default().add_modifier(Modifier::BOLD),
                     ),
                     Span::raw(format!("{} agents · {}", r.agents, r.sources)),
@@ -1092,6 +1114,36 @@ mod tests {
             .collect()
     }
 
+    /// Terminal column of each row containing `needle`, measured in cells
+    /// rather than string bytes. `render` above concatenates cell symbols,
+    /// and a wide glyph fills one cell and leaves the next holding a space,
+    /// so an index into that string is not a column: two aligned rows can
+    /// look misaligned there, and misaligned ones aligned.
+    fn columns_of(app: &App, width: u16, height: u16, needle: &str) -> Vec<u16> {
+        let backend = ratatui::backend::TestBackend::new(width, height);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal.draw(|f| draw(f, app)).unwrap();
+        let buffer = terminal.backend().buffer().clone();
+        let mut hits = Vec::new();
+        for y in 0..height {
+            let cells: Vec<(u16, String)> = (0..width)
+                .map(|x| (x, buffer[(x, y)].symbol().to_string()))
+                .collect();
+            let line: String = cells.iter().map(|(_, s)| s.as_str()).collect();
+            if let Some(byte) = line.find(needle) {
+                let mut acc = 0usize;
+                for (x, s) in &cells {
+                    if acc == byte {
+                        hits.push(*x);
+                        break;
+                    }
+                    acc += s.len();
+                }
+            }
+        }
+        hits
+    }
+
     #[test]
     fn newest_message_is_visible_without_scrolling() {
         // The bug: counting one row per message undershoots the bottom
@@ -1147,9 +1199,9 @@ mod tests {
     }
 
     #[test]
-    fn post_error_is_surfaced_in_the_input_title() {
+    fn last_error_is_surfaced_in_the_input_title() {
         let app = App {
-            post_error: Some("disk on fire".into()),
+            last_error: Some("post failed: disk on fire".into()),
             ..App::default()
         };
         assert!(render(&app, 60, 12).join("\n").contains("disk on fire"));
@@ -1526,7 +1578,7 @@ mod tests {
     #[test]
     fn a_switch_that_cannot_open_the_room_changes_nothing_at_all() {
         // The half-applied switch: input taken, draft stashed, the old room
-        // marked read, `post_error` cleared — but `app.room` still the old
+        // marked read, `last_error` cleared — but `app.room` still the old
         // room. The pane then displays and posts to room A while holding
         // room B's draft, which is one company's text one Enter away from
         // another company's room.
@@ -1536,11 +1588,14 @@ mod tests {
         a.room = named("alare");
         a.input = "alare draft".into();
         a.messages = vec![msg("bob", "alare chatter")];
-        a.post_error = Some("an earlier failure".into());
+        a.last_error = Some("an earlier failure".into());
         a.unread_seeds.insert(named("alare"), 11);
         a.dir = Some(crate::paths::room_dir(Some("alare")).unwrap());
+        a.scroll_from_bottom = 4;
+        a.title = title_for(&named("alare"));
+        a.members = vec![at("alare-1", "/w/alare/api")];
 
-        // A room name that cannot become a directory, so `room_dir` fails
+        // A room whose path is an ordinary file, so reading its log fails
         // where every other step would have succeeded.
         std::fs::write(session.join("wall"), b"not a directory").unwrap();
         let err = switch(&mut a, named("wall"), &session, &herd);
@@ -1553,9 +1608,82 @@ mod tests {
             "a draft was stashed by a failed switch"
         );
         assert_eq!(a.unread_seeds.get(&named("alare")), Some(&11));
-        assert_eq!(a.post_error.as_deref(), Some("an earlier failure"));
+        assert_eq!(a.last_error.as_deref(), Some("an earlier failure"));
         assert_eq!(a.messages.len(), 1);
         assert_eq!(a.dir, Some(crate::paths::room_dir(Some("alare")).unwrap()));
+        // Everything else the switch would have moved, so the guarantee is
+        // "nothing changed" rather than "the fields I remembered".
+        assert_eq!(a.scroll_from_bottom, 4);
+        assert_eq!(a.title, " scuttlebutt · alare ");
+        let names: Vec<&str> = a.members.iter().map(|m| m.name.as_str()).collect();
+        assert_eq!(names, vec!["alare-1"]);
+    }
+
+    #[test]
+    fn a_failed_switch_leaves_no_directory_behind_for_the_room_it_could_not_open() {
+        // `room_dir` would have created it before the read could fail, and
+        // an empty directory is exactly what `groups::has_history` filters
+        // out of every listing.
+        let (_d, _env, session) = scratch();
+        let mut a = app();
+        a.room = named("alare");
+        std::fs::write(session.join("wall"), b"not a directory").unwrap();
+
+        // a switch that succeeds does create the room's directory
+        assert!(switch(&mut a, named("ghost"), &session, &FakeHerd(vec![], false)).is_ok());
+        assert!(session.join("ghost").is_dir());
+
+        assert!(switch(&mut a, named("wall"), &session, &FakeHerd(vec![], false)).is_err());
+        assert!(
+            !session.join("wall").is_dir(),
+            "a failed switch created the room directory anyway"
+        );
+    }
+
+    #[test]
+    fn a_roomless_pane_keeps_its_way_out_even_when_something_has_failed() {
+        // Ctrl-K is the only exit from a pane that resolved to no room, and
+        // that pane is the case #35 exists to rescue. An error displacing
+        // the hint makes it a dead pane again.
+        let a = App {
+            last_error: Some("could not open that room: Not a directory".into()),
+            ..App::default()
+        };
+        let screen = render(&a, 90, 12).join("\n");
+        assert!(screen.contains("Ctrl-K"), "the way out is gone:\n{screen}");
+        assert!(screen.contains("could not open that room"), "{screen}");
+    }
+
+    #[test]
+    fn a_failed_switch_is_never_reported_as_a_failed_post() {
+        // The switch is a no-op when it fails, so nothing was posted and
+        // nothing was attempted; "post failed" describes an action nobody
+        // took.
+        let (_d, _env, session) = scratch();
+        let mut a = app();
+        a.room = named("alare");
+        std::fs::write(session.join("wall"), b"not a directory").unwrap();
+        let e = switch(&mut a, named("wall"), &session, &FakeHerd(vec![], false)).unwrap_err();
+        let reported = format!("could not open that room: {e}");
+
+        // Every arm of the input-line match, not just the one this pane
+        // happens to be in: a fixed "post failed" prefix reintroduced in any
+        // of them is the same lie.
+        for (room, home) in [
+            (CurrentRoom::NoneSelected, CurrentRoom::NoneSelected),
+            (named("alare"), named("alare")),
+            (named("alare"), named("acme")),
+        ] {
+            let pane = App {
+                room,
+                home,
+                last_error: Some(reported.clone()),
+                ..App::default()
+            };
+            let screen = render(&pane, 90, 12).join("\n");
+            assert!(!screen.contains("post failed"), "{screen}");
+            assert!(screen.contains("could not open that room"), "{screen}");
+        }
     }
 
     #[test]
@@ -1566,7 +1694,7 @@ mod tests {
         let a = App {
             room: named("acme"),
             home: named("alare"),
-            post_error: Some("disk on fire".into()),
+            last_error: Some("post failed: disk on fire".into()),
             ..App::default()
         };
         let screen = render(&a, 70, 12).join("\n");
@@ -1587,9 +1715,9 @@ mod tests {
     fn a_post_failure_does_not_follow_you_into_the_next_room() {
         let (_d, _env, session) = scratch();
         let mut a = app();
-        a.post_error = Some("disk on fire".into());
+        a.last_error = Some("post failed: disk on fire".into());
         switch(&mut a, named("acme"), &session, &FakeHerd(vec![], false)).unwrap();
-        assert_eq!(a.post_error, None);
+        assert_eq!(a.last_error, None);
     }
 
     #[test]
@@ -1815,6 +1943,33 @@ mod tests {
         assert_eq!(
             labelled,
             vec![("alare", "live agents"), ("acme", "history")]
+        );
+    }
+
+    #[test]
+    fn a_wide_room_name_does_not_push_the_picker_columns_out_of_line() {
+        // `{:<20}` pads by chars; a CJK name is twice as wide as it is long,
+        // so its detail column would start four cells late.
+        let mut a = app();
+        a.picker = Some(PickerState {
+            rows: ["一二三四", "acme"]
+                .iter()
+                .map(|n| PickerRow {
+                    room: CurrentRoom::Named((*n).into()),
+                    agents: 0,
+                    sources: "config".into(),
+                    unread: false,
+                })
+                .collect(),
+            filter: String::new(),
+            cursor: 0,
+        });
+        let screen = render(&a, 90, 12).join("\n");
+        let columns = columns_of(&a, 90, 12, "0 agents");
+        assert_eq!(columns.len(), 2, "expected both rows:\n{screen}");
+        assert_eq!(
+            columns[0], columns[1],
+            "detail columns are misaligned:\n{screen}"
         );
     }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -455,15 +455,23 @@ fn switch_room(
     if target == app.room {
         return Ok(());
     }
+    let carried = std::mem::take(&mut app.input);
     if app.room.selected().is_some() {
-        app.drafts
-            .insert(app.room.clone(), std::mem::take(&mut app.input));
+        app.drafts.insert(app.room.clone(), carried);
         // Re-seed the room being left so visiting it clears its dot; its log
         // has been read up to here.
         let len = room_len(session_dir, &app.room);
         app.unread_seeds.insert(app.room.clone(), len);
+        app.input = app.drafts.remove(&target).unwrap_or_default();
+    } else {
+        // Text typed with no room selected was not typed *for* a room —
+        // there was none — so it follows the human into the first one they
+        // pick rather than being stashed under a room nobody can return to.
+        // Stashing it would be the silent discard per-room drafts exist to
+        // prevent, since `NoneSelected` is unreachable again once a room is
+        // chosen.
+        app.input = app.drafts.remove(&target).unwrap_or(carried);
     }
-    app.input = app.drafts.remove(&target).unwrap_or_default();
     app.scroll_from_bottom = 0;
     // A write failure belonged to the room it was attempted in.
     app.post_error = None;
@@ -1398,6 +1406,34 @@ mod tests {
         assert_eq!(a.input, "half-written note for alare");
         switch(&mut a, named("acme"), &session, &herd).unwrap();
         assert_eq!(a.input, "something for acme");
+    }
+
+    #[test]
+    fn text_typed_before_a_room_existed_follows_you_into_the_first_one() {
+        // A roomless pane can be typed into — `handle_key` only gates the
+        // *post* — and `NoneSelected` is unreachable once a room is picked,
+        // so stashing that text under it would discard it for good.
+        let (_d, _env, session) = scratch();
+        let mut a = App {
+            input: "typed before picking a room".into(),
+            ..App::default()
+        };
+        switch(&mut a, named("acme"), &session, &FakeHerd(vec![], false)).unwrap();
+        assert_eq!(a.input, "typed before picking a room");
+    }
+
+    #[test]
+    fn a_carried_draft_never_overwrites_one_already_waiting() {
+        let (_d, _env, session) = scratch();
+        let herd = FakeHerd(vec![], false);
+        let mut a = app();
+        a.room = named("acme");
+        a.input = "acme's own draft".into();
+        switch(&mut a, named("alare"), &session, &herd).unwrap();
+        switch(&mut a, CurrentRoom::NoneSelected, &session, &herd).unwrap();
+        a.input = "typed with no room".into();
+        switch(&mut a, named("acme"), &session, &herd).unwrap();
+        assert_eq!(a.input, "acme's own draft");
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,12 +1,72 @@
+use crate::groups::{CurrentRoom, Grouping, Room};
 use crate::herd::{AgentInfo, HerdControl, RealHerd};
 use crate::log_store::{self, Message};
 use anyhow::Result;
 use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
-use ratatui::layout::{Constraint, Direction, Layout};
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph};
+use ratatui::widgets::{Block, Borders, Clear, List, ListItem, Paragraph};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 use unicode_width::UnicodeWidthChar;
+
+/// One row of the room picker, built once when the picker opens.
+///
+/// Everything a row displays is settled here rather than at draw time: the
+/// unread dot would otherwise stat a file on every keystroke, and `sources`
+/// would be a second derivation of the provenance `Room` already sorted by
+/// — the drift that `Room::sources` exists to make impossible.
+pub struct PickerRow {
+    pub room: CurrentRoom,
+    pub agents: usize,
+    /// `Room::sources` labels, primary first, joined for display.
+    pub sources: String,
+    /// The room's `room.jsonl` has grown since this pane started. Never set
+    /// for the room being viewed, whose log grows past its seed as you read.
+    pub unread: bool,
+}
+
+/// The modal room list. Its presence is the pane's only mode: `handle_key`
+/// returns early into `handle_picker_key` while it is `Some`.
+pub struct PickerState {
+    /// Rebuilt on every open, `herdr agent list` subprocess included. It
+    /// runs on a human keystroke, so the cost is invisible and the list is
+    /// fresh at the only moment anyone reads it.
+    pub rows: Vec<PickerRow>,
+    /// Case-insensitive substring, not prefix: group names here share stems
+    /// and hyphens, so `scuttle` has to find `herdr-scuttlebutt`.
+    pub filter: String,
+    /// Index into the *filtered* rows. Every mutation of `filter` resets it,
+    /// so it can never point past a narrowed list or at a row the human did
+    /// not put the cursor on.
+    pub cursor: usize,
+}
+
+impl PickerState {
+    fn matches(&self) -> Vec<&PickerRow> {
+        let needle = self.filter.to_lowercase();
+        self.rows
+            .iter()
+            .filter(|r| r.room.label().to_lowercase().contains(&needle))
+            .collect()
+    }
+
+    fn selected(&self) -> Option<CurrentRoom> {
+        self.matches().get(self.cursor).map(|r| r.room.clone())
+    }
+}
+
+/// What a keystroke asks the run loop to do. The picker's work — listing
+/// agents, reading another room's log — is IO that `handle_key` cannot do
+/// and that tests should not need a terminal for, so keys name the action
+/// and `run` performs it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Action {
+    Post(String),
+    OpenPicker,
+    Switch(CurrentRoom),
+}
 
 #[derive(Default)]
 pub struct App {
@@ -21,21 +81,48 @@ pub struct App {
     /// Message-pane title, always naming the resolved group so the human
     /// can never mistake which room's input line they are typing into.
     pub title: String,
+    /// The room being viewed, and the one a post goes to.
+    pub room: CurrentRoom,
+    /// The room this pane opened in, `--group` included. Never recomputed
+    /// from the live cwd: a pane opened with `--group` would then be
+    /// permanently "away" from a home it is sitting in, inverting the
+    /// away-from-home marker on the input border.
+    pub home: CurrentRoom,
+    /// `room`'s directory, `None` while no room is selected.
+    pub dir: Option<PathBuf>,
+    pub picker: Option<PickerState>,
+    /// Unsent input per room, stashed on switch-out and restored on
+    /// switch-in. Without it a draft either follows you into the next room
+    /// or is silently dropped.
+    pub drafts: HashMap<CurrentRoom, String>,
+    /// `room.jsonl` length per room when this pane started, refreshed for a
+    /// room as you leave it. An unread dot is this compared against the
+    /// file's length now, so it means "arrived while this pane has been
+    /// open" rather than "history exists".
+    pub unread_seeds: HashMap<CurrentRoom, u64>,
 }
 
-pub fn handle_key(app: &mut App, code: KeyCode, modifiers: KeyModifiers) -> Option<String> {
+pub fn handle_key(app: &mut App, code: KeyCode, modifiers: KeyModifiers) -> Option<Action> {
+    // The pane's one mode check. A branch per key would leave whichever key
+    // was added next routing into `app.input` behind an open modal.
+    if app.picker.is_some() {
+        return handle_picker_key(app, code, modifiers);
+    }
     match (code, modifiers) {
         (KeyCode::Char('c'), KeyModifiers::CONTROL) | (KeyCode::Esc, _) => {
             app.quit = true;
             None
         }
+        (KeyCode::Char('k'), KeyModifiers::CONTROL) => Some(Action::OpenPicker),
         (KeyCode::Enter, _) => {
-            if app.input.trim().is_empty() {
+            // Nowhere to post to, and clearing the input would discard what
+            // was typed with nothing written anywhere.
+            if app.room.selected().is_none() || app.input.trim().is_empty() {
                 None
             } else {
                 let text = std::mem::take(&mut app.input);
                 app.scroll_from_bottom = 0;
-                Some(text)
+                Some(Action::Post(text))
             }
         }
         (KeyCode::Backspace, _) => {
@@ -55,6 +142,52 @@ pub fn handle_key(app: &mut App, code: KeyCode, modifiers: KeyModifiers) -> Opti
             None
         }
         _ => None,
+    }
+}
+
+/// Keys while the room picker is open. `Esc` closes the modal instead of
+/// quitting the pane — safe only because the modal is on screen; an
+/// unconditional quit would train people to lose the pane.
+fn handle_picker_key(app: &mut App, code: KeyCode, modifiers: KeyModifiers) -> Option<Action> {
+    match (code, modifiers) {
+        (KeyCode::Char('c'), KeyModifiers::CONTROL) => {
+            app.quit = true;
+            None
+        }
+        (KeyCode::Esc, _) | (KeyCode::Char('k'), KeyModifiers::CONTROL) => {
+            app.picker = None;
+            None
+        }
+        (KeyCode::Enter, _) => {
+            // A filter matching nothing leaves no room to select; the modal
+            // stays open rather than closing onto an unchanged pane.
+            let chosen = app.picker.as_ref()?.selected()?;
+            app.picker = None;
+            Some(Action::Switch(chosen))
+        }
+        _ => {
+            let picker = app.picker.as_mut()?;
+            match (code, modifiers) {
+                (KeyCode::Up, _) => picker.cursor = picker.cursor.saturating_sub(1),
+                (KeyCode::Down, _) => {
+                    picker.cursor =
+                        (picker.cursor + 1).min(picker.matches().len().saturating_sub(1))
+                }
+                (KeyCode::Backspace, _) => {
+                    picker.filter.pop();
+                    picker.cursor = 0;
+                }
+                (KeyCode::Char(c), KeyModifiers::NONE | KeyModifiers::SHIFT) => {
+                    picker.filter.push(c);
+                    // Widening or narrowing changes which room each index
+                    // names, so holding the old index would move the cursor
+                    // to a room nobody pointed it at.
+                    picker.cursor = 0;
+                }
+                _ => {}
+            }
+            None
+        }
     }
 }
 
@@ -174,7 +307,9 @@ fn scroll_start(total_rows: usize, visible_rows: usize, scroll_from_bottom: usiz
 fn title_for(resolved: Option<&str>) -> String {
     match resolved {
         Some(g) => format!(" scuttlebutt · {g} "),
-        None => " scuttlebutt ".to_string(),
+        // Parenthesised because `valid_group_name` forbids parentheses, so
+        // it can never collide with a real group's name.
+        None => " scuttlebutt · (ungrouped) ".to_string(),
     }
 }
 
@@ -199,44 +334,195 @@ fn scoped_members(
     )
 }
 
+/// A room's directory under `session_dir`. The ungrouped room is
+/// `session_dir` itself, mirroring `paths::room_dir`.
+fn room_path(session_dir: &Path, room: &CurrentRoom) -> Option<PathBuf> {
+    match room {
+        CurrentRoom::Named(n) => Some(session_dir.join(n)),
+        CurrentRoom::Ungrouped => Some(session_dir.to_path_buf()),
+        CurrentRoom::NoneSelected => None,
+    }
+}
+
+/// Bytes in a room's `room.jsonl`, 0 if it has none.
+///
+/// Length, never `log_store::last_id`: that answers the same question by
+/// parsing the whole file — 292 KB for one real room — and the unread check
+/// runs for every room each time the picker opens.
+fn room_len(session_dir: &Path, room: &CurrentRoom) -> u64 {
+    room_path(session_dir, room)
+        .and_then(|d| std::fs::metadata(d.join("room.jsonl")).ok())
+        .map(|m| m.len())
+        .unwrap_or(0)
+}
+
+/// Every room's log length at pane start, which is what an unread dot is
+/// measured against. Swept straight off disk: this runs before the first
+/// draw, and `groups::rooms` would spend a `herdr agent list` subprocess to
+/// answer a question about file sizes.
+///
+/// A room created after this sweep has no seed and reads as 0, so it is
+/// dotted — correct, since everything in it did arrive while the pane was
+/// open.
+fn seed_unread(session_dir: &Path) -> HashMap<CurrentRoom, u64> {
+    let mut seeds = HashMap::new();
+    seeds.insert(
+        CurrentRoom::Ungrouped,
+        room_len(session_dir, &CurrentRoom::Ungrouped),
+    );
+    if let Ok(entries) = std::fs::read_dir(session_dir) {
+        for e in entries.flatten() {
+            if let Ok(name) = e.file_name().into_string() {
+                let room = CurrentRoom::Named(name);
+                let len = room_len(session_dir, &room);
+                seeds.insert(room, len);
+            }
+        }
+    }
+    seeds
+}
+
+/// Builds the modal's rows. Called on every open so the list — live agent
+/// counts included — is current at the moment someone reads it.
+fn open_picker(
+    app: &App,
+    session_dir: &Path,
+    herd: &dyn HerdControl,
+    grouping: &Grouping,
+    orgs: &mut crate::git_org::OrgCache,
+) -> PickerState {
+    let agents = herd.list_agents().unwrap_or_default();
+    let rooms: Vec<Room> = crate::groups::rooms(grouping, &agents, session_dir, orgs);
+    let rows = rooms
+        .iter()
+        .map(|r| {
+            let room = CurrentRoom::from(r);
+            PickerRow {
+                agents: r.agents,
+                // The one derivation of provenance, shared with the order
+                // `rooms` already sorted these into.
+                sources: r
+                    .sources()
+                    .iter()
+                    .map(|s| s.label())
+                    .collect::<Vec<_>>()
+                    .join(", "),
+                unread: room != app.room
+                    && room_len(session_dir, &room)
+                        > app.unread_seeds.get(&room).copied().unwrap_or(0),
+                room,
+            }
+        })
+        .collect();
+    PickerState {
+        rows,
+        filter: String::new(),
+        cursor: 0,
+    }
+}
+
+/// Points the pane at `target`, moving everything that is scoped to a room.
+///
+/// Members are refreshed here rather than left to the 3-second tick, which
+/// would otherwise leave one room's agent names beside another room's title
+/// — the leak `scoped_members` exists to prevent. The caller resets its
+/// refresh timer for the same reason.
+fn switch_room(
+    app: &mut App,
+    target: CurrentRoom,
+    session_dir: &Path,
+    herd: &dyn HerdControl,
+    grouping: &Grouping,
+    orgs: &mut crate::git_org::OrgCache,
+) -> Result<()> {
+    if target == app.room {
+        return Ok(());
+    }
+    if app.room.selected().is_some() {
+        app.drafts
+            .insert(app.room.clone(), std::mem::take(&mut app.input));
+        // Re-seed the room being left so visiting it clears its dot; its log
+        // has been read up to here.
+        let len = room_len(session_dir, &app.room);
+        app.unread_seeds.insert(app.room.clone(), len);
+    }
+    app.input = app.drafts.remove(&target).unwrap_or_default();
+    app.scroll_from_bottom = 0;
+    // A write failure belonged to the room it was attempted in.
+    app.post_error = None;
+
+    match target.selected() {
+        Some(group) => {
+            let dir = crate::paths::room_dir(group)?;
+            // A clean read of the whole file, never `should_reseed`: that
+            // asks whether *this* room's log was truncated, and it would be
+            // comparing this room's cursor against another room's last id.
+            app.messages = log_store::read_since(&dir, 0)?;
+            app.members = scoped_members(herd, group, grouping, orgs).unwrap_or_default();
+            app.title = title_for(group);
+            app.dir = Some(dir);
+        }
+        None => {
+            // `scoped_members(None, ..)` is the *ungrouped* room's roster,
+            // so it is not the answer here: no room is selected, and nobody
+            // is in one.
+            app.messages = Vec::new();
+            app.members = Vec::new();
+            app.title = " scuttlebutt · no room selected ".to_string();
+            app.dir = None;
+        }
+    }
+    app.room = target;
+    Ok(())
+}
+
 pub fn run(group: Option<&str>) -> Result<()> {
     let grouping = crate::groups::load(&crate::paths::base_dir()?);
     let mut orgs = crate::git_org::OrgCache::default();
-    let resolved =
-        crate::cli::resolve_group(group, &std::env::current_dir()?, &grouping, &mut orgs)?;
-    let dir = crate::paths::room_dir(resolved.as_deref())?;
-    let title = title_for(resolved.as_deref());
+    // Not `resolve_group`: an active config matching nothing opens the pane
+    // with no room selected and the picker up, which is the one state where
+    // a switcher is the whole point. `Broken` still bails inside.
+    let home = crate::cli::resolve_room(group, &std::env::current_dir()?, &grouping, &mut orgs)?;
+    let session_dir = crate::paths::session_dir()?;
     let herd = RealHerd;
     let mut app = App {
-        messages: log_store::read_since(&dir, 0)?,
-        members: scoped_members(&herd, resolved.as_deref(), &grouping, &mut orgs)
-            .unwrap_or_default(),
-        title,
+        unread_seeds: seed_unread(&session_dir),
+        // Seeded by the switch below, which is the same code path every
+        // later switch takes.
+        title: " scuttlebutt · no room selected ".to_string(),
+        home: home.clone(),
         ..App::default()
     };
+    switch_room(&mut app, home, &session_dir, &herd, &grouping, &mut orgs)?;
+    if app.room.selected().is_none() {
+        app.picker = Some(open_picker(&app, &session_dir, &herd, &grouping, &mut orgs));
+    }
 
     let mut terminal = ratatui::init();
     let mut last_member_refresh = std::time::Instant::now();
     let result = (|| -> Result<()> {
         while !app.quit {
             // tail new messages every loop; members on a slow tick
-            let last = app.messages.last().map(|m| m.id).unwrap_or(0);
-            let file_last = log_store::last_id(&dir)?;
-            if should_reseed(last, file_last) {
-                // room.jsonl was truncated or replaced (ids restarted lower
-                // than our cursor); discard the stale in-memory tail and
-                // re-seed from the start of the file instead of filtering
-                // every future message out forever.
-                app.messages = log_store::read_since(&dir, 0)?;
-            } else {
-                let mut fresh = log_store::read_since(&dir, last)?;
-                app.messages.append(&mut fresh);
-            }
-            if last_member_refresh.elapsed() > std::time::Duration::from_secs(3) {
-                if let Some(m) = scoped_members(&herd, resolved.as_deref(), &grouping, &mut orgs) {
-                    app.members = m;
+            if let Some(dir) = app.dir.clone() {
+                let last = app.messages.last().map(|m| m.id).unwrap_or(0);
+                let file_last = log_store::last_id(&dir)?;
+                if should_reseed(last, file_last) {
+                    // room.jsonl was truncated or replaced (ids restarted
+                    // lower than our cursor); discard the stale in-memory
+                    // tail and re-seed from the start of the file instead of
+                    // filtering every future message out forever.
+                    app.messages = log_store::read_since(&dir, 0)?;
+                } else {
+                    let mut fresh = log_store::read_since(&dir, last)?;
+                    app.messages.append(&mut fresh);
                 }
-                last_member_refresh = std::time::Instant::now();
+                if last_member_refresh.elapsed() > std::time::Duration::from_secs(3) {
+                    let group = app.room.selected().flatten().map(str::to_string);
+                    if let Some(m) = scoped_members(&herd, group.as_deref(), &grouping, &mut orgs) {
+                        app.members = m;
+                    }
+                    last_member_refresh = std::time::Instant::now();
+                }
             }
 
             terminal.draw(|f| draw(f, &app))?;
@@ -244,11 +530,44 @@ pub fn run(group: Option<&str>) -> Result<()> {
             if event::poll(std::time::Duration::from_millis(250))? {
                 if let Event::Key(key) = event::read()? {
                     if key.kind == KeyEventKind::Press {
-                        if let Some(text) = handle_key(&mut app, key.code, key.modifiers) {
-                            app.post_error = match log_store::append(&dir, "human", &text) {
-                                Ok(_) => None,
-                                Err(e) => Some(e.to_string()),
-                            };
+                        match handle_key(&mut app, key.code, key.modifiers) {
+                            Some(Action::Post(text)) => {
+                                // `handle_key` only returns this with a room
+                                // selected, so a pane with none never reaches
+                                // an append with no directory.
+                                if let Some(dir) = &app.dir {
+                                    app.post_error = match log_store::append(dir, "human", &text) {
+                                        Ok(_) => None,
+                                        Err(e) => Some(e.to_string()),
+                                    };
+                                }
+                            }
+                            Some(Action::OpenPicker) => {
+                                app.picker = Some(open_picker(
+                                    &app,
+                                    &session_dir,
+                                    &herd,
+                                    &grouping,
+                                    &mut orgs,
+                                ));
+                            }
+                            Some(Action::Switch(target)) => {
+                                switch_room(
+                                    &mut app,
+                                    target,
+                                    &session_dir,
+                                    &herd,
+                                    &grouping,
+                                    &mut orgs,
+                                )?;
+                                // `switch_room` just refreshed the roster;
+                                // without this the tick could fire again
+                                // immediately and is wasted work, and a
+                                // failed listing would blank the pane it
+                                // just filled.
+                                last_member_refresh = std::time::Instant::now();
+                            }
+                            None => {}
                         }
                     }
                 }
@@ -316,14 +635,94 @@ fn draw(f: &mut ratatui::Frame, app: &App) {
         top[1],
     );
 
-    let input_title = match &app.post_error {
-        Some(e) => format!(" post failed: {e} "),
-        None => " message (Enter to send, Esc to quit) ".to_string(),
+    // The input line is where a post is committed, so it carries the
+    // away-from-home marker: a colour *and* the room's name, because a
+    // colour alone says nothing about which room you are about to post in.
+    let away = app.room.selected().is_some() && app.room != app.home;
+    let (input_title, border) = match (&app.post_error, app.room.selected().is_some(), away) {
+        (Some(e), _, _) => (format!(" post failed: {e} "), Color::Red),
+        (None, false, _) => (
+            " no room selected — Ctrl-K to pick a room ".to_string(),
+            Color::DarkGray,
+        ),
+        (None, true, true) => (
+            format!(
+                " message → {} (Enter to send, Ctrl-K to switch) ",
+                app.room.label()
+            ),
+            Color::Yellow,
+        ),
+        (None, true, false) => (
+            " message (Enter to send, Ctrl-K rooms, Esc to quit) ".to_string(),
+            Color::Reset,
+        ),
     };
     f.render_widget(
-        Paragraph::new(app.input.as_str())
-            .block(Block::default().borders(Borders::ALL).title(input_title)),
+        Paragraph::new(app.input.as_str()).block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(border))
+                .title(input_title),
+        ),
         outer[1],
+    );
+
+    if let Some(picker) = &app.picker {
+        draw_picker(f, picker);
+    }
+}
+
+/// The modal room list, drawn last and over a cleared rectangle so the chat
+/// behind it cannot bleed through and be mistaken for a row.
+fn draw_picker(f: &mut ratatui::Frame, picker: &PickerState) {
+    let area = f.area();
+    // `.min(area.*)` is not redundant with the subtraction: a pane only a
+    // few cells tall subtracts to 0 and the lower clamp bound pushes it back
+    // above the buffer.
+    let w = area.width.saturating_sub(8).clamp(1, 64).min(area.width);
+    let h = area.height.saturating_sub(4).clamp(3, 16).min(area.height);
+    let rect = Rect {
+        x: area.x + (area.width.saturating_sub(w)) / 2,
+        y: area.y + (area.height.saturating_sub(h)) / 2,
+        width: w,
+        height: h,
+    };
+    let matches = picker.matches();
+    let items: Vec<ListItem> = matches
+        .iter()
+        .enumerate()
+        .map(|(i, r)| {
+            let row = if i == picker.cursor {
+                Style::default().add_modifier(Modifier::REVERSED)
+            } else {
+                Style::default()
+            };
+            ListItem::new(
+                Line::from(vec![
+                    Span::styled(
+                        if r.unread { "● " } else { "  " },
+                        Style::default().fg(Color::Yellow),
+                    ),
+                    Span::styled(
+                        format!("{:<20}", r.room.label()),
+                        Style::default().add_modifier(Modifier::BOLD),
+                    ),
+                    Span::raw(format!("{} agents · {}", r.agents, r.sources)),
+                ])
+                .style(row),
+            )
+        })
+        .collect();
+    let title = format!(" rooms · filter: {}_ ", picker.filter);
+    f.render_widget(Clear, rect);
+    f.render_widget(
+        List::new(items).block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(Color::Cyan))
+                .title(title),
+        ),
+        rect,
     );
 }
 
@@ -332,8 +731,14 @@ mod tests {
     use super::*;
     use crossterm::event::{KeyCode, KeyModifiers};
 
+    /// A pane in the ungrouped room. Explicit because `App::default()` is a
+    /// pane with *no* room selected, where posting is disabled by design.
     fn app() -> App {
-        App::default()
+        App {
+            room: CurrentRoom::Ungrouped,
+            home: CurrentRoom::Ungrouped,
+            ..App::default()
+        }
     }
 
     #[test]
@@ -349,7 +754,7 @@ mod tests {
         let mut a = app();
         a.input = "hello".into();
         let submitted = handle_key(&mut a, KeyCode::Enter, KeyModifiers::NONE);
-        assert_eq!(submitted.as_deref(), Some("hello"));
+        assert_eq!(submitted, Some(Action::Post("hello".into())));
         assert_eq!(a.input, "");
     }
 
@@ -546,10 +951,17 @@ mod tests {
     }
 
     #[test]
-    fn title_for_ungrouped_has_no_stray_group_label() {
-        let title = title_for(None);
-        assert!(!title.contains("·"));
-        assert!(title.contains("scuttlebutt"));
+    fn title_for_names_the_ungrouped_room() {
+        // Every room is named in the title, the ungrouped one included; a
+        // bare " scuttlebutt " left the one room with no label on screen.
+        assert_eq!(title_for(None), " scuttlebutt · (ungrouped) ");
+    }
+
+    #[test]
+    fn the_ungrouped_label_can_never_collide_with_a_real_group() {
+        assert!(!crate::groups::valid_group_name(
+            CurrentRoom::Ungrouped.label()
+        ));
     }
 
     /// Renders `draw` into an off-screen terminal and returns the rows as
@@ -676,6 +1088,517 @@ mod tests {
         let rows = wrap_text(text, 8, 8);
         let rejoined: String = rows.concat();
         assert_eq!(rejoined, text);
+    }
+
+    // --- picker ---
+
+    fn picker_of(names: &[&str]) -> PickerState {
+        PickerState {
+            rows: names
+                .iter()
+                .map(|n| PickerRow {
+                    room: CurrentRoom::Named((*n).into()),
+                    agents: 0,
+                    sources: "config".into(),
+                    unread: false,
+                })
+                .collect(),
+            filter: String::new(),
+            cursor: 0,
+        }
+    }
+
+    #[test]
+    fn ctrl_k_asks_to_open_the_picker() {
+        let mut a = app();
+        assert_eq!(
+            handle_key(&mut a, KeyCode::Char('k'), KeyModifiers::CONTROL),
+            Some(Action::OpenPicker)
+        );
+    }
+
+    #[test]
+    fn esc_closes_the_picker_instead_of_quitting_the_pane() {
+        // An unconditional quit here would train people to lose the pane.
+        let mut a = app();
+        a.picker = Some(picker_of(&["alare"]));
+        handle_key(&mut a, KeyCode::Esc, KeyModifiers::NONE);
+        assert!(a.picker.is_none());
+        assert!(!a.quit);
+        // and only then does Esc quit
+        handle_key(&mut a, KeyCode::Esc, KeyModifiers::NONE);
+        assert!(a.quit);
+    }
+
+    #[test]
+    fn typing_behind_an_open_picker_never_reaches_the_message_input() {
+        let mut a = app();
+        a.picker = Some(picker_of(&["alare"]));
+        handle_key(&mut a, KeyCode::Char('h'), KeyModifiers::NONE);
+        assert_eq!(a.input, "");
+        assert_eq!(a.picker.as_ref().unwrap().filter, "h");
+    }
+
+    #[test]
+    fn the_filter_matches_a_substring_not_a_prefix() {
+        // Group names here share stems and hyphens, so prefix matching would
+        // make the longest names the hardest to reach.
+        let mut a = app();
+        a.picker = Some(picker_of(&["herdr-scuttlebutt", "alare"]));
+        for c in "scuttle".chars() {
+            handle_key(&mut a, KeyCode::Char(c), KeyModifiers::NONE);
+        }
+        let p = a.picker.as_ref().unwrap();
+        let shown: Vec<&str> = p.matches().iter().map(|r| r.room.label()).collect();
+        assert_eq!(shown, vec!["herdr-scuttlebutt"]);
+    }
+
+    #[test]
+    fn the_filter_ignores_case_in_both_directions() {
+        let mut a = app();
+        a.picker = Some(picker_of(&["Alare"]));
+        for c in "aLaR".chars() {
+            handle_key(&mut a, KeyCode::Char(c), KeyModifiers::NONE);
+        }
+        assert_eq!(a.picker.as_ref().unwrap().matches().len(), 1);
+    }
+
+    #[test]
+    fn enter_selects_the_room_under_the_cursor() {
+        let mut a = app();
+        a.picker = Some(picker_of(&["acme", "alare"]));
+        handle_key(&mut a, KeyCode::Down, KeyModifiers::NONE);
+        assert_eq!(
+            handle_key(&mut a, KeyCode::Enter, KeyModifiers::NONE),
+            Some(Action::Switch(CurrentRoom::Named("alare".into())))
+        );
+        assert!(a.picker.is_none());
+    }
+
+    #[test]
+    fn the_cursor_stops_at_both_ends_of_the_list() {
+        let mut a = app();
+        a.picker = Some(picker_of(&["acme", "alare"]));
+        for _ in 0..5 {
+            handle_key(&mut a, KeyCode::Down, KeyModifiers::NONE);
+        }
+        assert_eq!(a.picker.as_ref().unwrap().cursor, 1);
+        for _ in 0..5 {
+            handle_key(&mut a, KeyCode::Up, KeyModifiers::NONE);
+        }
+        assert_eq!(a.picker.as_ref().unwrap().cursor, 0);
+    }
+
+    #[test]
+    fn narrowing_the_filter_cannot_leave_the_cursor_on_a_room_nobody_chose() {
+        // The bug this prevents: cursor on row 2, type until only row 0
+        // survives, press Enter, and switch to whatever the stale index now
+        // names — or index past the list entirely.
+        let mut a = app();
+        a.picker = Some(picker_of(&["acme", "alare", "zebra"]));
+        handle_key(&mut a, KeyCode::Down, KeyModifiers::NONE);
+        handle_key(&mut a, KeyCode::Down, KeyModifiers::NONE);
+        handle_key(&mut a, KeyCode::Char('c'), KeyModifiers::NONE);
+        assert_eq!(
+            handle_key(&mut a, KeyCode::Enter, KeyModifiers::NONE),
+            Some(Action::Switch(CurrentRoom::Named("acme".into())))
+        );
+    }
+
+    #[test]
+    fn enter_on_a_filter_that_matches_nothing_leaves_the_picker_open() {
+        let mut a = app();
+        a.picker = Some(picker_of(&["alare"]));
+        for c in "zzz".chars() {
+            handle_key(&mut a, KeyCode::Char(c), KeyModifiers::NONE);
+        }
+        assert_eq!(handle_key(&mut a, KeyCode::Enter, KeyModifiers::NONE), None);
+        assert!(a.picker.is_some());
+        assert!(!a.quit);
+    }
+
+    #[test]
+    fn backspace_widens_the_filter_again() {
+        let mut a = app();
+        a.picker = Some(picker_of(&["alare", "acme"]));
+        for c in "al".chars() {
+            handle_key(&mut a, KeyCode::Char(c), KeyModifiers::NONE);
+        }
+        assert_eq!(a.picker.as_ref().unwrap().matches().len(), 1);
+        handle_key(&mut a, KeyCode::Backspace, KeyModifiers::NONE);
+        assert_eq!(a.picker.as_ref().unwrap().matches().len(), 2);
+    }
+
+    #[test]
+    fn ctrl_c_still_quits_from_inside_the_picker() {
+        let mut a = app();
+        a.picker = Some(picker_of(&["alare"]));
+        handle_key(&mut a, KeyCode::Char('c'), KeyModifiers::CONTROL);
+        assert!(a.quit);
+    }
+
+    // --- no room selected ---
+
+    #[test]
+    fn a_pane_with_no_room_selected_cannot_post() {
+        // Not merely "nothing is written": the draft must survive, because
+        // clearing the input would discard it with nothing written anywhere.
+        let mut a = App {
+            input: "hello".into(),
+            ..App::default()
+        };
+        assert_eq!(handle_key(&mut a, KeyCode::Enter, KeyModifiers::NONE), None);
+        assert_eq!(a.input, "hello");
+    }
+
+    #[test]
+    fn a_pane_with_no_room_selected_says_so_and_offers_the_picker() {
+        let a = App {
+            title: " scuttlebutt · no room selected ".into(),
+            ..App::default()
+        };
+        let screen = render(&a, 60, 12).join("\n");
+        assert!(screen.contains("no room selected"), "{screen}");
+        assert!(screen.contains("Ctrl-K"), "{screen}");
+    }
+
+    #[test]
+    fn away_from_home_the_input_line_names_the_room_it_would_post_to() {
+        let a = App {
+            room: CurrentRoom::Named("acme".into()),
+            home: CurrentRoom::Named("alare".into()),
+            ..App::default()
+        };
+        let screen = render(&a, 60, 12).join("\n");
+        assert!(screen.contains("acme"), "{screen}");
+    }
+
+    #[test]
+    fn at_home_the_input_line_carries_no_room_marker() {
+        let a = App {
+            room: CurrentRoom::Named("alare".into()),
+            home: CurrentRoom::Named("alare".into()),
+            ..App::default()
+        };
+        assert!(!render(&a, 60, 12).join("\n").contains("→"));
+    }
+
+    #[test]
+    fn the_picker_renders_over_the_chat_behind_it() {
+        let mut a = app();
+        a.messages = (0..8)
+            .map(|i| msg("bob", &format!("chatter number {i} in the room")))
+            .collect();
+        a.picker = Some(PickerState {
+            rows: vec![PickerRow {
+                room: CurrentRoom::Named("alare".into()),
+                agents: 2,
+                sources: "live agents, config".into(),
+                unread: true,
+            }],
+            filter: String::new(),
+            cursor: 0,
+        });
+        let screen = render(&a, 90, 14).join("\n");
+        assert!(screen.contains("alare"), "{screen}");
+        assert!(screen.contains("2 agents"), "{screen}");
+        assert!(screen.contains("live agents, config"), "{screen}");
+        assert!(screen.contains("●"), "no unread dot:\n{screen}");
+    }
+
+    // --- switch mechanics ---
+
+    /// A scratch session dir wired up as the process's `SCUTTLEBUTT_DIR`, so
+    /// `switch_room` resolves rooms through `paths::room_dir` exactly as it
+    /// does in a real pane.
+    fn scratch() -> (
+        tempfile::TempDir,
+        std::sync::MutexGuard<'static, ()>,
+        PathBuf,
+    ) {
+        let env = crate::paths::env_guard();
+        let dir = tempfile::tempdir().unwrap();
+        std::env::set_var("SCUTTLEBUTT_DIR", dir.path());
+        std::env::set_var("HERDR_SOCKET_PATH", "/tmp/switch-test.sock");
+        let session = crate::paths::session_dir().unwrap();
+        (dir, env, session)
+    }
+
+    fn switch(
+        app: &mut App,
+        target: CurrentRoom,
+        session: &Path,
+        herd: &dyn HerdControl,
+    ) -> Result<()> {
+        switch_room(
+            app,
+            target,
+            session,
+            herd,
+            &crate::groups::Grouping::Inactive,
+            &mut orgs(no_org),
+        )
+    }
+
+    fn named(n: &str) -> CurrentRoom {
+        CurrentRoom::Named(n.into())
+    }
+
+    #[test]
+    fn switching_shows_the_target_rooms_messages_and_title() {
+        let (_d, _env, session) = scratch();
+        log_store::append(
+            &crate::paths::room_dir(Some("acme")).unwrap(),
+            "bob",
+            "in acme",
+        )
+        .unwrap();
+        let mut a = app();
+        a.messages = vec![msg("bob", "in the old room")];
+        switch(&mut a, named("acme"), &session, &FakeHerd(vec![], false)).unwrap();
+
+        let texts: Vec<&str> = a.messages.iter().map(|m| m.text.as_str()).collect();
+        assert_eq!(texts, vec!["in acme"]);
+        assert_eq!(a.title, " scuttlebutt · acme ");
+        assert_eq!(a.dir, Some(crate::paths::room_dir(Some("acme")).unwrap()));
+    }
+
+    #[test]
+    fn a_draft_waits_in_the_room_it_was_typed_in() {
+        // Both failure modes at once: a draft following you into another
+        // room, and a draft silently discarded on the way out.
+        let (_d, _env, session) = scratch();
+        let herd = FakeHerd(vec![], false);
+        let mut a = app();
+        a.room = named("alare");
+        a.input = "half-written note for alare".into();
+
+        switch(&mut a, named("acme"), &session, &herd).unwrap();
+        assert_eq!(a.input, "");
+        a.input = "something for acme".into();
+
+        switch(&mut a, named("alare"), &session, &herd).unwrap();
+        assert_eq!(a.input, "half-written note for alare");
+        switch(&mut a, named("acme"), &session, &herd).unwrap();
+        assert_eq!(a.input, "something for acme");
+    }
+
+    #[test]
+    fn switching_returns_to_the_newest_message() {
+        let (_d, _env, session) = scratch();
+        let mut a = app();
+        a.scroll_from_bottom = 7;
+        switch(&mut a, named("acme"), &session, &FakeHerd(vec![], false)).unwrap();
+        assert_eq!(a.scroll_from_bottom, 0);
+    }
+
+    #[test]
+    fn a_post_failure_does_not_follow_you_into_the_next_room() {
+        let (_d, _env, session) = scratch();
+        let mut a = app();
+        a.post_error = Some("disk on fire".into());
+        switch(&mut a, named("acme"), &session, &FakeHerd(vec![], false)).unwrap();
+        assert_eq!(a.post_error, None);
+    }
+
+    #[test]
+    fn the_roster_changes_with_the_room_rather_than_on_the_next_tick() {
+        // The 3-second tick would otherwise leave one room's agent names
+        // beside another room's title.
+        let (_d, _env, session) = scratch();
+        let herd = FakeHerd(
+            vec![at("issue-590", "/w/alare/api"), at("acme-x", "/w/acme")],
+            false,
+        );
+        let mut a = app();
+        a.members = vec![at("stale", "/w/alare/api")];
+        switch_room(
+            &mut a,
+            named("acme"),
+            &session,
+            &herd,
+            &crate::groups::Grouping::Inactive,
+            &mut orgs(fake_org),
+        )
+        .unwrap();
+        let names: Vec<&str> = a.members.iter().map(|m| m.name.as_str()).collect();
+        assert_eq!(names, vec!["acme-x"]);
+    }
+
+    #[test]
+    fn an_unresolvable_pane_can_pick_its_way_into_a_room() {
+        // The state that is dead today: no room selected, nothing to post
+        // to, and the picker as the only way out.
+        let (_d, _env, session) = scratch();
+        let mut a = App::default();
+        assert!(a.room.selected().is_none());
+        assert_eq!(handle_key(&mut a, KeyCode::Enter, KeyModifiers::NONE), None);
+
+        switch(&mut a, named("acme"), &session, &FakeHerd(vec![], false)).unwrap();
+        assert_eq!(a.room, named("acme"));
+        a.input = "now I can post".into();
+        assert_eq!(
+            handle_key(&mut a, KeyCode::Enter, KeyModifiers::NONE),
+            Some(Action::Post("now I can post".into()))
+        );
+    }
+
+    #[test]
+    fn leaving_a_room_for_no_room_empties_the_pane_rather_than_showing_the_shared_room() {
+        // `scoped_members(None, ..)` is the *ungrouped* room's roster, so
+        // passing the absence straight through would fill a roomless pane
+        // with every agent outside a repository.
+        let (_d, _env, session) = scratch();
+        let herd = FakeHerd(vec![at("nowhere", "/elsewhere")], false);
+        let mut a = app();
+        a.room = named("acme");
+        a.messages = vec![msg("bob", "acme chatter")];
+        a.members = vec![at("acme-x", "/w/acme")];
+        switch(&mut a, CurrentRoom::NoneSelected, &session, &herd).unwrap();
+        assert!(a.messages.is_empty());
+        assert!(a.members.is_empty());
+        assert_eq!(a.dir, None);
+        assert_eq!(a.title, " scuttlebutt · no room selected ");
+    }
+
+    // --- unread dots ---
+
+    fn post_to(room: &str, text: &str) {
+        log_store::append(&crate::paths::room_dir(Some(room)).unwrap(), "bob", text).unwrap();
+    }
+
+    #[test]
+    fn a_room_that_grew_since_the_pane_opened_is_dotted() {
+        let (_d, _env, session) = scratch();
+        post_to("acme", "history from before");
+        let mut a = app();
+        a.unread_seeds = seed_unread(&session);
+        post_to("acme", "arrived while the pane was open");
+
+        let p = open_picker(
+            &a,
+            &session,
+            &FakeHerd(vec![], false),
+            &crate::groups::Grouping::Inactive,
+            &mut orgs(no_org),
+        );
+        let acme = p.rows.iter().find(|r| r.room == named("acme")).unwrap();
+        assert!(acme.unread, "acme grew since the seed and is not dotted");
+    }
+
+    #[test]
+    fn history_that_predates_the_pane_is_not_unread() {
+        let (_d, _env, session) = scratch();
+        post_to("acme", "history from before");
+        let mut a = app();
+        a.unread_seeds = seed_unread(&session);
+        let p = open_picker(
+            &a,
+            &session,
+            &FakeHerd(vec![], false),
+            &crate::groups::Grouping::Inactive,
+            &mut orgs(no_org),
+        );
+        let acme = p.rows.iter().find(|r| r.room == named("acme")).unwrap();
+        assert!(!acme.unread, "a dot here would mean 'history exists'");
+    }
+
+    #[test]
+    fn the_room_being_read_is_never_dotted() {
+        // Its log grows past its seed as you read it.
+        let (_d, _env, session) = scratch();
+        let mut a = app();
+        a.unread_seeds = seed_unread(&session);
+        a.room = named("acme");
+        post_to("acme", "a message you are looking at");
+        let p = open_picker(
+            &a,
+            &session,
+            &FakeHerd(vec![], false),
+            &crate::groups::Grouping::Inactive,
+            &mut orgs(no_org),
+        );
+        let acme = p.rows.iter().find(|r| r.room == named("acme")).unwrap();
+        assert!(!acme.unread);
+    }
+
+    #[test]
+    fn visiting_a_room_clears_its_dot() {
+        let (_d, _env, session) = scratch();
+        let herd = FakeHerd(vec![], false);
+        let mut a = app();
+        a.unread_seeds = seed_unread(&session);
+        a.room = named("alare");
+        post_to("acme", "unread while you were in alare");
+
+        switch(&mut a, named("acme"), &session, &herd).unwrap();
+        switch(&mut a, named("alare"), &session, &herd).unwrap();
+
+        let p = open_picker(
+            &a,
+            &session,
+            &herd,
+            &crate::groups::Grouping::Inactive,
+            &mut orgs(no_org),
+        );
+        let acme = p.rows.iter().find(|r| r.room == named("acme")).unwrap();
+        assert!(!acme.unread, "acme was visited and should be caught up");
+    }
+
+    #[test]
+    fn a_room_created_after_the_pane_opened_is_dotted() {
+        let (_d, _env, session) = scratch();
+        let a = App {
+            unread_seeds: seed_unread(&session),
+            room: named("alare"),
+            ..App::default()
+        };
+        post_to("acme", "a room that did not exist at pane start");
+        let p = open_picker(
+            &a,
+            &session,
+            &FakeHerd(vec![], false),
+            &crate::groups::Grouping::Inactive,
+            &mut orgs(no_org),
+        );
+        let acme = p.rows.iter().find(|r| r.room == named("acme")).unwrap();
+        assert!(acme.unread);
+    }
+
+    #[test]
+    fn picker_rows_take_their_provenance_from_the_order_they_are_listed_in() {
+        // One derivation, shared with the sort: a row labelled "config"
+        // sitting above a row with agents in it is the drift `Room::sources`
+        // exists to prevent.
+        let (_d, _env, session) = scratch();
+        post_to("acme", "history only");
+        let herd = FakeHerd(vec![at("alare-1", "/w/alare/api")], false);
+        let a = App::default();
+        let p = open_picker(
+            &a,
+            &session,
+            &herd,
+            &crate::groups::Grouping::Inactive,
+            &mut orgs(fake_org),
+        );
+        let labelled: Vec<(&str, &str)> = p
+            .rows
+            .iter()
+            .map(|r| (r.room.label(), r.sources.as_str()))
+            .collect();
+        assert_eq!(
+            labelled,
+            vec![("alare", "live agents"), ("acme", "history")]
+        );
+    }
+
+    #[test]
+    fn the_picker_survives_a_pane_too_small_to_hold_it() {
+        let mut a = app();
+        a.picker = Some(picker_of(&["alare"]));
+        for (w, h) in [(1, 1), (4, 2), (10, 3), (0, 0)] {
+            render(&a, w, h);
+        }
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -309,21 +309,23 @@ fn scroll_start(total_rows: usize, visible_rows: usize, scroll_from_bottom: usiz
     bottom.saturating_sub(scroll_from_bottom.min(bottom))
 }
 
-/// Message-pane title for a selected room. Always names it, the ungrouped
-/// room included, so no room can be on screen unlabelled.
+/// Message-pane title. Always names the room being viewed — a group, the
+/// ungrouped room, or none selected — so no state can be on screen
+/// unlabelled.
+///
+/// The name comes from `CurrentRoom::label`, the same spelling the picker
+/// rows show and its filter searches, so what the title says is what you
+/// can type to get back here. Spelling `(ungrouped)` a second time is how
+/// the two would drift apart. `label` is parenthesised for exactly this:
+/// `valid_group_name` forbids parentheses, so it can never collide with a
+/// real group's name.
 ///
 /// It is only half the safeguard against typing into the wrong company's
 /// room now that a pane can switch: this titles the *messages*, while the
 /// input line — where a post is committed — carries its own marker once the
-/// pane is away from the room it opened in. A pane with no room selected
-/// does not come through here at all; it has no group to name.
-fn title_for(resolved: Option<&str>) -> String {
-    match resolved {
-        Some(g) => format!(" scuttlebutt · {g} "),
-        // Parenthesised because `valid_group_name` forbids parentheses, so
-        // it can never collide with a real group's name.
-        None => " scuttlebutt · (ungrouped) ".to_string(),
-    }
+/// pane is away from the room it opened in.
+fn title_for(room: &CurrentRoom) -> String {
+    format!(" scuttlebutt · {} ", room.label())
 }
 
 /// The members pane's roster, scoped to the resolved group. The initial
@@ -351,14 +353,13 @@ fn scoped_members(
     )
 }
 
-/// A room's directory under `session_dir`. The ungrouped room is
-/// `session_dir` itself, mirroring `paths::room_dir`.
+/// A room's directory under `session_dir`, or `None` when no room is
+/// selected. Shares `paths::room_dir_in` with `room_dir` rather than joining
+/// the path a second time, and inherits its refusal to create anything: this
+/// runs for every room on every picker open.
 fn room_path(session_dir: &Path, room: &CurrentRoom) -> Option<PathBuf> {
-    match room {
-        CurrentRoom::Named(n) => Some(session_dir.join(n)),
-        CurrentRoom::Ungrouped => Some(session_dir.to_path_buf()),
-        CurrentRoom::NoneSelected => None,
-    }
+    room.selected()
+        .map(|g| crate::paths::room_dir_in(session_dir, g))
 }
 
 /// Bytes in a room's `room.jsonl`, 0 if it has none.
@@ -424,9 +425,13 @@ fn open_picker(
                     .map(|s| s.label())
                     .collect::<Vec<_>>()
                     .join(", "),
+                // Changed, not merely grown: a truncated or replaced log
+                // is shorter than its seed, and `>` would leave it
+                // permanently undotted however much arrived afterwards —
+                // the case `should_reseed` exists for, one file along.
                 unread: room != app.room
                     && room_len(session_dir, &room)
-                        > app.unread_seeds.get(&room).copied().unwrap_or(0),
+                        != app.unread_seeds.get(&room).copied().unwrap_or(0),
                 room,
             }
         })
@@ -455,6 +460,31 @@ fn switch_room(
     if target == app.room {
         return Ok(());
     }
+    // Everything that can fail happens here, before a single byte of the
+    // pane's room-scoped state moves. `paths::room_dir` reaches `base_dir`,
+    // which spawns `herdr plugin config-dir` unless SCUTTLEBUTT_DIR is set,
+    // so a failing switch is a subprocess hiccup away rather than
+    // theoretical — and a half-applied one leaves room A on screen holding
+    // room B's draft, which is the next Enter posting one company's text
+    // into another company's room.
+    let loaded = match target.selected() {
+        Some(group) => {
+            let dir = crate::paths::room_dir(group)?;
+            // A clean read of the whole file, never `should_reseed`: that
+            // asks whether *this* room's log was truncated, and it would be
+            // comparing this room's cursor against another room's last id.
+            let messages = log_store::read_since(&dir, 0)?;
+            // A failed listing is not a failed switch: `scoped_members`
+            // returns `None` for it, and an empty roster beside the new
+            // room's title is honest, where the old room's names would not
+            // be.
+            let members = scoped_members(herd, group, grouping, orgs).unwrap_or_default();
+            Some((dir, messages, members))
+        }
+        None => None,
+    };
+
+    // From here nothing fails, so the pane cannot be left half-switched.
     let carried = std::mem::take(&mut app.input);
     if app.room.selected().is_some() {
         app.drafts.insert(app.room.clone(), carried);
@@ -476,15 +506,10 @@ fn switch_room(
     // A write failure belonged to the room it was attempted in.
     app.post_error = None;
 
-    match target.selected() {
-        Some(group) => {
-            let dir = crate::paths::room_dir(group)?;
-            // A clean read of the whole file, never `should_reseed`: that
-            // asks whether *this* room's log was truncated, and it would be
-            // comparing this room's cursor against another room's last id.
-            app.messages = log_store::read_since(&dir, 0)?;
-            app.members = scoped_members(herd, group, grouping, orgs).unwrap_or_default();
-            app.title = title_for(group);
+    match loaded {
+        Some((dir, messages, members)) => {
+            app.messages = messages;
+            app.members = members;
             app.dir = Some(dir);
         }
         None => {
@@ -493,10 +518,10 @@ fn switch_room(
             // is in one.
             app.messages = Vec::new();
             app.members = Vec::new();
-            app.title = " scuttlebutt · no room selected ".to_string();
             app.dir = None;
         }
     }
+    app.title = title_for(&target);
     app.room = target;
     Ok(())
 }
@@ -514,7 +539,7 @@ pub fn run(group: Option<&str>) -> Result<()> {
         unread_seeds: seed_unread(&session_dir),
         // Seeded by the switch below, which is the same code path every
         // later switch takes.
-        title: " scuttlebutt · no room selected ".to_string(),
+        title: title_for(&CurrentRoom::NoneSelected),
         home: home.clone(),
         ..App::default()
     };
@@ -541,12 +566,21 @@ pub fn run(group: Option<&str>) -> Result<()> {
                     let mut fresh = log_store::read_since(&dir, last)?;
                     app.messages.append(&mut fresh);
                 }
-                if last_member_refresh.elapsed() > std::time::Duration::from_secs(3) {
-                    let group = app.room.selected().flatten().map(str::to_string);
-                    if let Some(m) = scoped_members(&herd, group.as_deref(), &grouping, &mut orgs) {
-                        app.members = m;
+                // `selected()` is destructured, never flattened: flattening
+                // would hand `scoped_members` the ungrouped room's roster
+                // for a pane that has selected no room, which is the
+                // conflation `CurrentRoom` exists to make unsayable. The
+                // outer `if let` makes that unreachable today; relying on
+                // that would leave the leak one refactor away.
+                if let Some(group) = app.room.selected().map(|g| g.map(str::to_string)) {
+                    if last_member_refresh.elapsed() > std::time::Duration::from_secs(3) {
+                        if let Some(m) =
+                            scoped_members(&herd, group.as_deref(), &grouping, &mut orgs)
+                        {
+                            app.members = m;
+                        }
+                        last_member_refresh = std::time::Instant::now();
                     }
-                    last_member_refresh = std::time::Instant::now();
                 }
             }
 
@@ -577,20 +611,32 @@ pub fn run(group: Option<&str>) -> Result<()> {
                                 ));
                             }
                             Some(Action::Switch(target)) => {
-                                switch_room(
+                                match switch_room(
                                     &mut app,
                                     target,
                                     &session_dir,
                                     &herd,
                                     &grouping,
                                     &mut orgs,
-                                )?;
-                                // `switch_room` just refreshed the roster;
-                                // without this the tick could fire again
-                                // immediately and is wasted work, and a
-                                // failed listing would blank the pane it
-                                // just filled.
-                                last_member_refresh = std::time::Instant::now();
+                                ) {
+                                    // `switch_room` just refreshed the
+                                    // roster; without this the tick could
+                                    // fire again immediately and is wasted
+                                    // work, and a failed listing would blank
+                                    // the pane it just filled.
+                                    Ok(()) => last_member_refresh = std::time::Instant::now(),
+                                    // Same standard the input line already
+                                    // holds write failures to: a transient
+                                    // failure must not tear the chat pane
+                                    // down. `switch_room` is a no-op when it
+                                    // fails, so the pane is still showing
+                                    // the room it was in, with every draft
+                                    // where it was left.
+                                    Err(e) => {
+                                        app.post_error =
+                                            Some(format!("could not open that room: {e}"))
+                                    }
+                                }
                             }
                             None => {}
                         }
@@ -664,8 +710,19 @@ fn draw(f: &mut ratatui::Frame, app: &App) {
     // away-from-home marker: a colour *and* the room's name, because a
     // colour alone says nothing about which room you are about to post in.
     let away = app.room.selected().is_some() && app.room != app.home;
+    // A post failure never displaces the away-from-home marker. The failure
+    // is the moment the human is about to retype and press Enter, so
+    // swapping the room name out for the error would switch the safeguard
+    // off at the one moment it is doing work. Both are shown, room first,
+    // and the border stays away-yellow rather than error-red: a reader who
+    // has learned that yellow means "not your room" must not lose it to a
+    // transient write error.
     let (input_title, border) = match (&app.post_error, app.room.selected().is_some(), away) {
-        (Some(e), _, _) => (format!(" post failed: {e} "), Color::Red),
+        (Some(e), _, true) => (
+            format!(" → {} · post failed: {e} ", app.room.label()),
+            Color::Yellow,
+        ),
+        (Some(e), _, false) => (format!(" post failed: {e} "), Color::Red),
         (None, false, _) => (
             " no room selected — Ctrl-K to pick a room ".to_string(),
             Color::DarkGray,
@@ -972,14 +1029,44 @@ mod tests {
 
     #[test]
     fn title_for_names_the_group() {
-        assert!(title_for(Some("alare")).contains("alare"));
+        assert!(title_for(&named("alare")).contains("alare"));
     }
 
     #[test]
     fn title_for_names_the_ungrouped_room() {
         // Every room is named in the title, the ungrouped one included; a
         // bare " scuttlebutt " left the one room with no label on screen.
-        assert_eq!(title_for(None), " scuttlebutt · (ungrouped) ");
+        assert_eq!(
+            title_for(&CurrentRoom::Ungrouped),
+            " scuttlebutt · (ungrouped) "
+        );
+    }
+
+    #[test]
+    fn title_for_names_a_pane_that_has_no_room() {
+        assert_eq!(
+            title_for(&CurrentRoom::NoneSelected),
+            " scuttlebutt · no room selected "
+        );
+    }
+
+    #[test]
+    fn the_title_spells_a_room_the_way_the_picker_filter_reads_it() {
+        // `label`'s promise is "what you can see is what you can type", and
+        // a title that spelled the room a second way would break it without
+        // failing any test of `label` alone.
+        for room in [
+            named("alare"),
+            CurrentRoom::Ungrouped,
+            CurrentRoom::NoneSelected,
+        ] {
+            assert!(
+                title_for(&room).contains(room.label()),
+                "title {:?} does not contain {:?}",
+                title_for(&room),
+                room.label()
+            );
+        }
     }
 
     #[test]
@@ -1437,6 +1524,57 @@ mod tests {
     }
 
     #[test]
+    fn a_switch_that_cannot_open_the_room_changes_nothing_at_all() {
+        // The half-applied switch: input taken, draft stashed, the old room
+        // marked read, `post_error` cleared — but `app.room` still the old
+        // room. The pane then displays and posts to room A while holding
+        // room B's draft, which is one company's text one Enter away from
+        // another company's room.
+        let (_d, _env, session) = scratch();
+        let herd = FakeHerd(vec![], false);
+        let mut a = app();
+        a.room = named("alare");
+        a.input = "alare draft".into();
+        a.messages = vec![msg("bob", "alare chatter")];
+        a.post_error = Some("an earlier failure".into());
+        a.unread_seeds.insert(named("alare"), 11);
+        a.dir = Some(crate::paths::room_dir(Some("alare")).unwrap());
+
+        // A room name that cannot become a directory, so `room_dir` fails
+        // where every other step would have succeeded.
+        std::fs::write(session.join("wall"), b"not a directory").unwrap();
+        let err = switch(&mut a, named("wall"), &session, &herd);
+        assert!(err.is_err(), "expected this switch to fail");
+
+        assert_eq!(a.room, named("alare"));
+        assert_eq!(a.input, "alare draft");
+        assert!(
+            a.drafts.is_empty(),
+            "a draft was stashed by a failed switch"
+        );
+        assert_eq!(a.unread_seeds.get(&named("alare")), Some(&11));
+        assert_eq!(a.post_error.as_deref(), Some("an earlier failure"));
+        assert_eq!(a.messages.len(), 1);
+        assert_eq!(a.dir, Some(crate::paths::room_dir(Some("alare")).unwrap()));
+    }
+
+    #[test]
+    fn a_post_failure_never_hides_which_room_the_post_would_go_to() {
+        // The safeguard would otherwise switch itself off at the one moment
+        // it is working: the human has just failed to post and is about to
+        // retype and press Enter.
+        let a = App {
+            room: named("acme"),
+            home: named("alare"),
+            post_error: Some("disk on fire".into()),
+            ..App::default()
+        };
+        let screen = render(&a, 70, 12).join("\n");
+        assert!(screen.contains("acme"), "room name is hidden:\n{screen}");
+        assert!(screen.contains("disk on fire"), "{screen}");
+    }
+
+    #[test]
     fn switching_returns_to_the_newest_message() {
         let (_d, _env, session) = scratch();
         let mut a = app();
@@ -1596,6 +1734,41 @@ mod tests {
         );
         let acme = p.rows.iter().find(|r| r.room == named("acme")).unwrap();
         assert!(!acme.unread, "acme was visited and should be caught up");
+    }
+
+    #[test]
+    fn a_truncated_room_is_still_dotted() {
+        // `len > seed` never fires again once a log is replaced by a shorter
+        // one, leaving that room permanently silent however much arrives.
+        let (_d, _env, session) = scratch();
+        post_to(
+            "acme",
+            "a long line of history that will be replaced wholesale",
+        );
+        let mut a = app();
+        a.unread_seeds = seed_unread(&session);
+        a.room = named("alare");
+        std::fs::write(
+            crate::paths::room_dir(Some("acme"))
+                .unwrap()
+                .join("room.jsonl"),
+            b"",
+        )
+        .unwrap();
+        post_to("acme", "short");
+
+        let p = open_picker(
+            &a,
+            &session,
+            &FakeHerd(vec![], false),
+            &crate::groups::Grouping::Inactive,
+            &mut orgs(no_org),
+        );
+        let acme = p.rows.iter().find(|r| r.room == named("acme")).unwrap();
+        assert!(
+            acme.unread,
+            "a replaced log left the room permanently silent"
+        );
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -78,8 +78,11 @@ pub struct App {
     /// Last post failure, surfaced in the input-line title. A transient write
     /// failure must not tear the chat pane down.
     pub post_error: Option<String>,
-    /// Message-pane title, always naming the resolved group so the human
-    /// can never mistake which room's input line they are typing into.
+    /// Message-pane title, always naming the room being viewed — a group,
+    /// the ungrouped room, or none selected. It is half the safeguard
+    /// against posting into the wrong company's room; the input line's
+    /// away-from-home marker is the other half, because that is where a
+    /// post is actually committed.
     pub title: String,
     /// The room being viewed, and the one a post goes to.
     pub room: CurrentRoom,
@@ -198,6 +201,10 @@ fn handle_picker_key(app: &mut App, code: KeyCode, modifiers: KeyModifiers) -> O
 /// cursor would filter out every subsequent message forever. In that case
 /// the caller should discard its in-memory messages and re-seed from the
 /// start of the file.
+///
+/// Only ever about the room currently being tailed. A room switch re-seeds
+/// unconditionally and must not come through here, which would compare one
+/// room's cursor against another room's last id.
 fn should_reseed(mem_last_id: u64, file_last_id: u64) -> bool {
     file_last_id < mem_last_id
 }
@@ -302,8 +309,14 @@ fn scroll_start(total_rows: usize, visible_rows: usize, scroll_from_bottom: usiz
     bottom.saturating_sub(scroll_from_bottom.min(bottom))
 }
 
-/// Message-pane title. Always names the resolved group, so it is the
-/// visible safeguard against typing into the wrong company's room.
+/// Message-pane title for a selected room. Always names it, the ungrouped
+/// room included, so no room can be on screen unlabelled.
+///
+/// It is only half the safeguard against typing into the wrong company's
+/// room now that a pane can switch: this titles the *messages*, while the
+/// input line — where a post is committed — carries its own marker once the
+/// pane is away from the room it opened in. A pane with no room selected
+/// does not come through here at all; it has no group to name.
 fn title_for(resolved: Option<&str>) -> String {
     match resolved {
         Some(g) => format!(" scuttlebutt · {g} "),
@@ -313,12 +326,16 @@ fn title_for(resolved: Option<&str>) -> String {
     }
 }
 
-/// The members pane's roster, scoped to the resolved group. Both the initial
-/// seed and the periodic refresh go through here: the pane sits beside a title
-/// naming the group, so an unscoped roster would show one company's agent
-/// names in another company's room. `None` on a failed listing, so the
-/// refresh can keep the last known roster instead of blanking the pane for a
-/// transient `herdr agent list` failure.
+/// The members pane's roster, scoped to the resolved group. The initial
+/// seed, the periodic refresh and every room switch go through here: the
+/// pane sits beside a title naming the group, so an unscoped roster would
+/// show one company's agent names in another company's room. `None` on a
+/// failed listing, so the refresh can keep the last known roster instead of
+/// blanking the pane for a transient `herdr agent list` failure.
+///
+/// `resolved` is a group or the ungrouped room, never "no room selected":
+/// `None` here means the shared room's roster, which is a real answer and
+/// the wrong one for a pane that has not picked a room.
 fn scoped_members(
     herd: &dyn HerdControl,
     resolved: Option<&str>,


### PR DESCRIPTION
Refs #35. Builds on #34 (`groups::rooms`, `Room::sources`).

`Ctrl-K` opens a modal room picker over the chat. Type to filter by
case-insensitive substring, `Up`/`Down` to move, `Enter` to switch, `Esc` to
close the modal rather than quit the pane. `handle_key` gates on
`App.picker` with one early return, so no key added later can leak into
`app.input` behind an open modal.

Posting follows the view. Away from the room the pane opened in, the input
border recolours and names the room it would post to — the pane title alone
is not where a post is committed. Home is the room the pane started in,
`--group` included, and is never recomputed from the live cwd.

An `Active` config that matches nothing now opens with no room selected and
the picker up, instead of refusing to open. It does **not** fall back to the
ungrouped room. `Broken` still bails: `rooms` lists nothing there, so a
picker could only offer every company's room swept off a config we could not
parse.

The current room is a three-state `groups::CurrentRoom` (a named group / the
ungrouped room / none selected). `Option<String>` would conflate the last
two, and the draft map and `title_for` would disagree the first time anyone
ran without a `groups.toml`.

Switching stashes the outgoing room's draft and restores the incoming one,
resets `scroll_from_bottom`, re-seeds with a clean `read_since(dir, 0)`
(never via `should_reseed`, which asks a different question), refreshes
members synchronously and resets the refresh timer. Unread dots come from
`fs::metadata(room.jsonl).len()` against a seed taken at pane start — never
`log_store::last_id`, which parses the whole file. Session-only.

### Outside `src/tui.rs`

- `cli::resolve_room` is the three-state resolution, and `resolve_group`
  delegates to it, so the precedence rules stay written once rather than
  reimplemented in the TUI or recovered by matching on an error string.
- `title_for(None)` becomes `" scuttlebutt · (ungrouped) "`.
- README: the in-pane key sentence, and a note that a room can exist without
  being configured.
- Dropped the tautological `assert_eq!(primaries, sorted)` in
  `the_order_of_a_rooms_sources_matches_the_order_rooms_are_sorted_in`, per
  #34's own handoff, and said in its comment why the hardcoded vec is the
  half that catches skew.

### Verified

279 tests pass; `cargo clippy --all-targets` and `cargo fmt --check` clean.

Driven in a real tmux pane against a scratch `SCUTTLEBUTT_DIR` and the live
`herdr agent list`, not only against fixtures. Captured pane text confirms:
an unresolvable cwd opens with the picker up and posting disabled; `scuttle`
finds `herdr-scuttlebutt`; switching swaps messages, title and roster
together; a post lands in the viewed room's `room.jsonl`; drafts wait in the
room they were typed in; `Esc` closes the picker and leaves the pane alive;
an unread dot appears for a room that grew and clears on visiting it; a pane
opened with `--group` from an unresolvable cwd reads as at home; and a
`Broken` config still bails with no picker.

### Left out

`#38` and `#39` are out of scope. No version bump, no ADR. Persisting the
chosen room across a pane restart is deliberately not done — it needs a
per-pane key that does not exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FAKnjr9uHmFW5r2DZcPeE5