### PR TITLE
Split the failure cap into the two decisions it gated

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2792,8 +2792,11 @@ mod tests {
         herd.fail_prompts = true;
         tick(&mut state, &herd, dir.path(), &AgentFilter::default(), None).unwrap();
         let log = daemon_log(dir.path());
+        let cap = MAX_FAILURES_BEFORE_STALL;
         assert!(
-            log.contains("failed: stalled (batch 3/5, unconfirmed 2/5)"),
+            log.contains(&format!(
+                "failed: stalled (batch 3/{cap}, unconfirmed 2/{cap})"
+            )),
             "log was: {log}"
         );
     }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -8,9 +8,9 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, OnceLock};
 
-/// Non-deliveries to one agent before the daemon stops prompting it. Two
-/// counters reach it over different events: `fail_counts` counts every
-/// non-delivery of one batch and restarts when the batch grows, while
+/// Non-deliveries to one agent before the daemon stalls it. Two counters
+/// reach it over different events: `fail_counts` counts every non-delivery
+/// of one batch and restarts when the batch grows, while
 /// `unconfirmed_streak` counts only unconfirmed deliveries and ignores the
 /// batch. Either reaching this stalls the agent — its batch is held, its
 /// cursor left alone, and delivery drops to `retry_after`'s widening backoff
@@ -19,10 +19,18 @@ use std::sync::{Arc, OnceLock};
 /// `herdr agent list` for `MAX_ABSENCES` passes loses its cursor and its
 /// stall with the rest of its state, and re-enrolls at the tail.
 ///
-/// The intro prompt shares the constant and not the behaviour: it gives up
-/// and moves on, because a missing intro costs an explanation rather than a
-/// message.
-pub const MAX_BATCH_FAILURES: u32 = 5;
+/// The cost of reaching it is delivery itself: nothing else lands at that
+/// pane until the stall lifts. `MAX_INTRO_FAILURES` gates the other,
+/// cheaper give-up and is deliberately a separate number (#44).
+pub const MAX_FAILURES_BEFORE_STALL: u32 = 5;
+
+/// Failed intro prompts to one agent before the daemon stops trying to
+/// explain the room and marks it introduced anyway. It shares
+/// `MAX_FAILURES_BEFORE_STALL`'s value and not its behaviour: giving up here
+/// costs an agent the explanation of what scuttlebutt is, after which it
+/// still receives every batch, so the number is free to move on its own
+/// (#44). Nothing retries an intro once this is reached.
+pub const MAX_INTRO_FAILURES: u32 = 5;
 
 /// Delivery opportunities a freshly stalled agent waits before it is offered
 /// its batch again. At the 2s tick that is about a minute, which is long
@@ -1107,18 +1115,20 @@ pub fn tick(
                     report(
                         dir,
                         &format!(
-                            "[scuttlebutt] intro to {} {why} ({fails}/{MAX_BATCH_FAILURES})",
+                            "[scuttlebutt] intro to {} {why} ({fails}/{MAX_INTRO_FAILURES})",
                             a.name
                         ),
                     );
-                    if fails >= MAX_BATCH_FAILURES {
-                        // Same terminal action as a wedged batch: give up and
-                        // move on, so the agent still receives room traffic.
+                    if fails >= MAX_INTRO_FAILURES {
+                        // Terminal for the intro alone: give up and move on,
+                        // so the agent still receives room traffic. A wedged
+                        // batch stalls and holds instead (#39) — different
+                        // costs, hence the separate constants (#44).
                         report(
                             dir,
                             &format!(
                                 "[scuttlebutt] GIVING UP on intro for {} after \
-                                 {MAX_BATCH_FAILURES} failures; it will receive \
+                                 {MAX_INTRO_FAILURES} failures; it will receive \
                                  batches without an explanation",
                                 a.name
                             ),
@@ -1297,12 +1307,12 @@ pub fn tick(
                     dir,
                     &format!(
                         "[scuttlebutt] delivery to {} {why} \
-                         (batch {fails}/{MAX_BATCH_FAILURES}, \
-                         unconfirmed {streak}/{MAX_BATCH_FAILURES})",
+                         (batch {fails}/{MAX_FAILURES_BEFORE_STALL}, \
+                         unconfirmed {streak}/{MAX_FAILURES_BEFORE_STALL})",
                         a.name
                     ),
                 );
-                if fails >= MAX_BATCH_FAILURES || streak >= MAX_BATCH_FAILURES {
+                if fails >= MAX_FAILURES_BEFORE_STALL || streak >= MAX_FAILURES_BEFORE_STALL {
                     // The cursor stays where it is: advancing it here is what
                     // dropped the batch (#39). `fail_counts` and
                     // `unconfirmed_streak` are left standing too — clearing
@@ -1318,7 +1328,7 @@ pub fn tick(
                             dir,
                             &format!(
                                 "[scuttlebutt] STALLED: {} has not confirmed a delivery in \
-                                 {MAX_BATCH_FAILURES} attempts. Holding the batch up to \
+                                 {MAX_FAILURES_BEFORE_STALL} attempts. Holding the batch up to \
                                  #{max_id}; the room continues for everyone else. Delivery \
                                  to it drops to a widening retry and resumes on its own \
                                  when one is confirmed or a new session appears at that \
@@ -1669,16 +1679,16 @@ mod tests {
     }
 
     #[test]
-    fn failed_intro_gives_up_at_the_batch_cap() {
+    fn failed_intro_gives_up_at_the_intro_cap() {
         let dir = tempfile::tempdir().unwrap();
         let mut herd = FakeHerd::new(vec![("reviewer", "idle")]);
         herd.fail_prompts = true;
         let mut state = DaemonState::default();
         state.deliverable_streak.insert("reviewer".into(), 9);
-        for _ in 0..(MAX_BATCH_FAILURES - 1) {
+        for _ in 0..(MAX_INTRO_FAILURES - 1) {
             tick(&mut state, &herd, dir.path(), &AgentFilter::default(), None).unwrap();
         }
-        assert_eq!(state.intro_fails["reviewer"], MAX_BATCH_FAILURES - 1);
+        assert_eq!(state.intro_fails["reviewer"], MAX_INTRO_FAILURES - 1);
         assert!(!state.introduced.contains("reviewer"));
 
         tick(&mut state, &herd, dir.path(), &AgentFilter::default(), None).unwrap();
@@ -1970,12 +1980,15 @@ mod tests {
         introduced(&mut state, &["reviewer"]);
         state.cursors.insert("reviewer".into(), 0);
         append(dir.path(), "human", "hello").unwrap();
-        for _ in 0..(MAX_BATCH_FAILURES - 1) {
+        for _ in 0..(MAX_FAILURES_BEFORE_STALL - 1) {
             tick(&mut state, &herd, dir.path(), &AgentFilter::default(), None).unwrap();
         }
         // not yet at the cap: the batch is still pending, cursor unmoved
         assert_eq!(state.cursors["reviewer"], 0);
-        assert_eq!(state.fail_counts["reviewer"].0, MAX_BATCH_FAILURES - 1);
+        assert_eq!(
+            state.fail_counts["reviewer"].0,
+            MAX_FAILURES_BEFORE_STALL - 1
+        );
 
         tick(&mut state, &herd, dir.path(), &AgentFilter::default(), None).unwrap();
         // after the 5th consecutive failure the agent stalls: the batch is
@@ -1983,7 +1996,7 @@ mod tests {
         // says which agent is wedged
         assert_eq!(state.cursors["reviewer"], 0);
         assert_eq!(state.stalled["reviewer"].batch, 1);
-        assert_eq!(state.fail_counts["reviewer"].0, MAX_BATCH_FAILURES);
+        assert_eq!(state.fail_counts["reviewer"].0, MAX_FAILURES_BEFORE_STALL);
     }
 
     /// A prompt herdr accepted while leaving the text on the composer. This
@@ -2047,11 +2060,14 @@ mod tests {
         state.cursors.insert("reviewer".into(), 0);
         append(dir.path(), "human", "hello").unwrap();
 
-        for _ in 0..(MAX_BATCH_FAILURES - 1) {
+        for _ in 0..(MAX_FAILURES_BEFORE_STALL - 1) {
             tick(&mut state, &herd, dir.path(), &AgentFilter::default(), None).unwrap();
         }
         assert_eq!(state.cursors["reviewer"], 0);
-        assert_eq!(state.fail_counts["reviewer"].0, MAX_BATCH_FAILURES - 1);
+        assert_eq!(
+            state.fail_counts["reviewer"].0,
+            MAX_FAILURES_BEFORE_STALL - 1
+        );
 
         tick(&mut state, &herd, dir.path(), &AgentFilter::default(), None).unwrap();
         // one bad pane stalls itself, loudly, and keeps its batch
@@ -2075,7 +2091,7 @@ mod tests {
         state.cursors.insert("reviewer".into(), 0);
         append(dir.path(), "human", "hello").unwrap();
 
-        for _ in 0..MAX_BATCH_FAILURES {
+        for _ in 0..MAX_FAILURES_BEFORE_STALL {
             tick(&mut state, &herd, dir.path(), &AgentFilter::default(), None).unwrap();
         }
         assert_eq!(
@@ -2108,7 +2124,7 @@ mod tests {
         state.cursors.insert("builder".into(), 0);
         append(dir.path(), "human", "hello").unwrap();
 
-        for _ in 0..MAX_BATCH_FAILURES + 1 {
+        for _ in 0..MAX_FAILURES_BEFORE_STALL + 1 {
             tick(&mut state, &herd, dir.path(), &AgentFilter::default(), None).unwrap();
         }
         assert!(state.stalled.contains_key("reviewer"));
@@ -2141,7 +2157,7 @@ mod tests {
         state.cursors.insert("reviewer".into(), 0);
         append(dir.path(), "human", "hello").unwrap();
 
-        for i in 0..MAX_BATCH_FAILURES + 5 {
+        for i in 0..MAX_FAILURES_BEFORE_STALL + 5 {
             // the room keeps moving underneath the stalled agent
             append(dir.path(), "human", &format!("later {i}")).unwrap();
             tick(&mut state, &herd, dir.path(), &AgentFilter::default(), None).unwrap();
@@ -2166,7 +2182,7 @@ mod tests {
         state.cursors.insert("reviewer".into(), 0);
         append(dir.path(), "human", "hello").unwrap();
 
-        for _ in 0..MAX_BATCH_FAILURES {
+        for _ in 0..MAX_FAILURES_BEFORE_STALL {
             tick(&mut state, &herd, dir.path(), &AgentFilter::default(), None).unwrap();
         }
         assert!(state.stalled.contains_key("reviewer"));
@@ -2207,7 +2223,7 @@ mod tests {
         state.cursors.insert("reviewer".into(), 0);
         append(dir.path(), "human", "hello").unwrap();
 
-        for _ in 0..MAX_BATCH_FAILURES {
+        for _ in 0..MAX_FAILURES_BEFORE_STALL {
             tick(&mut state, &herd, dir.path(), &AgentFilter::default(), None).unwrap();
         }
         assert_eq!(state.stalled["reviewer"].session, None);
@@ -2235,7 +2251,7 @@ mod tests {
         state.cursors.insert("reviewer".into(), 0);
         append(dir.path(), "human", "hello").unwrap();
 
-        for _ in 0..MAX_BATCH_FAILURES {
+        for _ in 0..MAX_FAILURES_BEFORE_STALL {
             tick(&mut state, &herd, dir.path(), &AgentFilter::default(), None).unwrap();
         }
         let sent = herd.prompts.borrow().len();
@@ -2275,7 +2291,7 @@ mod tests {
         state.cursors.insert("reviewer".into(), 0);
         append(dir.path(), "human", "hello").unwrap();
 
-        for _ in 0..MAX_BATCH_FAILURES {
+        for _ in 0..MAX_FAILURES_BEFORE_STALL {
             tick(&mut state, &herd, dir.path(), &AgentFilter::default(), None).unwrap();
         }
         assert_eq!(state.stalled["reviewer"].held_since, 1);
@@ -2312,7 +2328,7 @@ mod tests {
         state.cursors.insert("reviewer".into(), 0);
         append(dir.path(), "human", "hello").unwrap();
 
-        for _ in 0..MAX_BATCH_FAILURES {
+        for _ in 0..MAX_FAILURES_BEFORE_STALL {
             tick(&mut state, &herd, dir.path(), &AgentFilter::default(), None).unwrap();
         }
         // the room moves on, and a retry fails against the bigger batch
@@ -2352,7 +2368,7 @@ mod tests {
         state.cursors.insert("reviewer".into(), 0);
         append(dir.path(), "human", "hello").unwrap();
 
-        for _ in 0..MAX_BATCH_FAILURES {
+        for _ in 0..MAX_FAILURES_BEFORE_STALL {
             tick(&mut state, &herd, dir.path(), &AgentFilter::default(), None).unwrap();
         }
         append(dir.path(), "human", "and another").unwrap();
@@ -2386,7 +2402,7 @@ mod tests {
         append(dir.path(), "human", "hello").unwrap();
 
         // seen with an id, then the field goes missing across the threshold
-        for _ in 0..MAX_BATCH_FAILURES - 1 {
+        for _ in 0..MAX_FAILURES_BEFORE_STALL - 1 {
             tick(&mut state, &herd, dir.path(), &AgentFilter::default(), None).unwrap();
         }
         herd.drop_session("reviewer");
@@ -2406,7 +2422,7 @@ mod tests {
             "a dropped field read as a restart"
         );
         assert_eq!(herd.prompts.borrow().len(), sent, "back to full rate");
-        assert_eq!(state.fail_counts["reviewer"].0, MAX_BATCH_FAILURES);
+        assert_eq!(state.fail_counts["reviewer"].0, MAX_FAILURES_BEFORE_STALL);
     }
 
     #[test]
@@ -2426,7 +2442,7 @@ mod tests {
         state.cursors.insert("reviewer".into(), 0);
         append(dir.path(), "human", "hello").unwrap();
 
-        for _ in 0..MAX_BATCH_FAILURES {
+        for _ in 0..MAX_FAILURES_BEFORE_STALL {
             tick(&mut state, &herd, dir.path(), &AgentFilter::default(), None).unwrap();
         }
         assert_eq!(
@@ -2476,7 +2492,7 @@ mod tests {
         state.cursors.insert("reviewer".into(), 0);
         append(dir.path(), "human", "hello").unwrap();
 
-        for _ in 0..MAX_BATCH_FAILURES {
+        for _ in 0..MAX_FAILURES_BEFORE_STALL {
             tick(&mut state, &herd, dir.path(), &AgentFilter::default(), None).unwrap();
         }
         assert_eq!(state.stalled["reviewer"].session, None);
@@ -2497,7 +2513,7 @@ mod tests {
         state.cursors.insert("reviewer".into(), 0);
         append(dir.path(), "human", "hello").unwrap();
 
-        for _ in 0..MAX_BATCH_FAILURES {
+        for _ in 0..MAX_FAILURES_BEFORE_STALL {
             tick(&mut state, &herd, dir.path(), &AgentFilter::default(), None).unwrap();
         }
         assert_eq!(
@@ -2546,7 +2562,7 @@ mod tests {
         state.cursors.insert("reviewer".into(), 0);
         append(dir.path(), "human", "hello").unwrap();
 
-        for _ in 0..MAX_BATCH_FAILURES {
+        for _ in 0..MAX_FAILURES_BEFORE_STALL {
             tick(&mut state, &herd, dir.path(), &AgentFilter::default(), None).unwrap();
         }
         assert!(state.stalled.contains_key("reviewer"));
@@ -2581,7 +2597,7 @@ mod tests {
         state.cursors.insert("reviewer".into(), 0);
         append(dir.path(), "human", "hello").unwrap();
 
-        for _ in 0..MAX_BATCH_FAILURES {
+        for _ in 0..MAX_FAILURES_BEFORE_STALL {
             tick(&mut state, &herd, dir.path(), &AgentFilter::default(), None).unwrap();
         }
         herd.unconfirmed.clear();
@@ -2603,7 +2619,7 @@ mod tests {
         state.cursors.insert("reviewer".into(), 0);
         append(dir.path(), "human", "hello").unwrap();
 
-        for _ in 0..MAX_BATCH_FAILURES {
+        for _ in 0..MAX_FAILURES_BEFORE_STALL {
             tick(&mut state, &herd, dir.path(), &AgentFilter::default(), None).unwrap();
         }
         let sent = herd.prompts.borrow().len();
@@ -2638,8 +2654,11 @@ mod tests {
         assert_eq!(state.stalled["reviewer"].retries, 2);
         // the counters that led to the stall are the record of it, and a
         // retry is not part of that record
-        assert_eq!(state.fail_counts["reviewer"].0, MAX_BATCH_FAILURES);
-        assert_eq!(state.unconfirmed_streak["reviewer"], MAX_BATCH_FAILURES);
+        assert_eq!(state.fail_counts["reviewer"].0, MAX_FAILURES_BEFORE_STALL);
+        assert_eq!(
+            state.unconfirmed_streak["reviewer"],
+            MAX_FAILURES_BEFORE_STALL
+        );
         let log = daemon_log(dir.path());
         assert_eq!(
             log.matches("STALLED: reviewer").count(),
@@ -2713,14 +2732,14 @@ mod tests {
         introduced(&mut state, &["reviewer"]);
         state.cursors.insert("reviewer".into(), 0);
 
-        for i in 0..MAX_BATCH_FAILURES {
+        for i in 0..MAX_FAILURES_BEFORE_STALL {
             append(dir.path(), "human", &format!("message {i}")).unwrap();
             tick(&mut state, &herd, dir.path(), &AgentFilter::default(), None).unwrap();
             // the per-batch counter never gets past its first failure
             assert_eq!(state.fail_counts.get("reviewer").map(|e| e.0), Some(1));
             assert_eq!(state.unconfirmed_streak["reviewer"], i + 1);
         }
-        let tail = u64::from(MAX_BATCH_FAILURES);
+        let tail = u64::from(MAX_FAILURES_BEFORE_STALL);
         // Converged means stopped prompting, not moved on: the batch is held
         // and the cursor is still where the last confirmed delivery left it.
         assert_eq!(state.stalled["reviewer"].batch, tail, "never converged");
@@ -2829,10 +2848,13 @@ mod tests {
         introduced(&mut state, &["reviewer"]);
         state.cursors.insert("reviewer".into(), 0);
         append(dir.path(), "human", "one").unwrap();
-        for _ in 0..(MAX_BATCH_FAILURES - 1) {
+        for _ in 0..(MAX_FAILURES_BEFORE_STALL - 1) {
             tick(&mut state, &herd, dir.path(), &AgentFilter::default(), None).unwrap();
         }
-        assert_eq!(state.fail_counts["reviewer"].0, MAX_BATCH_FAILURES - 1);
+        assert_eq!(
+            state.fail_counts["reviewer"].0,
+            MAX_FAILURES_BEFORE_STALL - 1
+        );
 
         // a new message grows the batch: this is not the same batch anymore
         append(dir.path(), "human", "two").unwrap();

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1232,8 +1232,9 @@ pub fn tick(
                 // The counters are left exactly as the stall found them,
                 // and `unconfirmed` goes unread for the same reason: they
                 // record how the threshold was reached, and counting
-                // retries into them would print `batch 6/5` and make the
-                // numbers mean two different things.
+                // retries into them would print a batch count past the cap
+                // it is shown against and make the numbers mean two
+                // different things.
                 let stall = state
                     .stalled
                     .get_mut(&a.name)
@@ -1293,8 +1294,9 @@ pub fn tick(
                 // every tick cannot keep an unconfirmable agent below the
                 // threshold forever. Only unconfirmed deliveries advance it,
                 // but the stored value is what gets reported either way: a
-                // hard error in the middle of a streak must not log 0/5 and
-                // make the eventual stall look like it came from nowhere.
+                // hard error in the middle of a streak must not log a
+                // streak of 0 and make the eventual stall look like it came
+                // from nowhere.
                 if unconfirmed {
                     *state.unconfirmed_streak.entry(a.name.clone()).or_insert(0) += 1;
                 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -29,7 +29,9 @@ pub const MAX_FAILURES_BEFORE_STALL: u32 = 5;
 /// `MAX_FAILURES_BEFORE_STALL`'s value and not its behaviour: giving up here
 /// costs an agent the explanation of what scuttlebutt is, after which it
 /// still receives every batch, so the number is free to move on its own
-/// (#44). Nothing retries an intro once this is reached.
+/// (#44). Nothing retries an intro within an enrollment; the absence purge
+/// is the only way back, because it drops `introduced` with the rest of the
+/// agent's state and the next listing introduces it afresh.
 pub const MAX_INTRO_FAILURES: u32 = 5;
 
 /// Delivery opportunities a freshly stalled agent waits before it is offered
@@ -2724,10 +2726,10 @@ mod tests {
 
     #[test]
     fn an_unconfirmable_agent_converges_while_the_room_is_busy() {
-        // The room this runs in gets traffic faster than five ticks, so the
-        // batch max id changes every pass and `fail_counts`' streak restarts
-        // every pass. Without a batch-independent counter the agent is
-        // re-prompted forever and never reaches the skip.
+        // The room this runs in gets traffic faster than the cap's worth of
+        // ticks, so the batch max id changes every pass and `fail_counts`'
+        // streak restarts every pass. Without a batch-independent counter the
+        // agent is re-prompted forever and never reaches the stall.
         let dir = tempfile::tempdir().unwrap();
         let herd = unconfirmed_for(&["reviewer"], vec![("reviewer", "idle")]);
         let mut state = DaemonState::default();

--- a/src/herd.rs
+++ b/src/herd.rs
@@ -890,8 +890,8 @@ mod tests {
         // — and `Some(false)` there advances the cursor over it.
         //
         // The cost is a repeat delivery per tick while a queue stands, and
-        // `MAX_FAILURES_BEFORE_STALL` still bounds it: after five of those
-        // the agent stalls, which holds the batch, leaves the cursor where
+        // `MAX_FAILURES_BEFORE_STALL` still bounds it: at the cap the
+        // agent stalls, which holds the batch, leaves the cursor where
         // it is, drops to a widening retry and names the agent in
         // `daemon-status` (#42). So the cost is bounded and logged, and
         // nothing is lost while it runs; this was a silent drop.

--- a/src/herd.rs
+++ b/src/herd.rs
@@ -890,8 +890,11 @@ mod tests {
         // — and `Some(false)` there advances the cursor over it.
         //
         // The cost is a repeat delivery per tick while a queue stands, and
-        // `MAX_BATCH_FAILURES` still force-advances after five of those
-        // (#39). That is a bounded, logged skip; this was a silent one.
+        // `MAX_FAILURES_BEFORE_STALL` still bounds it: after five of those
+        // the agent stalls, which holds the batch, leaves the cursor where
+        // it is, drops to a widening retry and names the agent in
+        // `daemon-status` (#42). So the cost is bounded and logged, and
+        // nothing is lost while it runs; this was a silent drop.
         assert_eq!(composer_holds(PLACEHOLDER, RULE), None);
     }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -34,8 +34,9 @@ pub struct DaemonState {
     #[serde(default)]
     pub intro_fails: HashMap<String, u32>,
     /// Agents whose batch or unconfirmed streak reached
-    /// `MAX_FAILURES_BEFORE_STALL` with nothing ever confirming a delivery. While an agent is in here the daemon leaves
-    /// its cursor alone and drops to a widening backoff instead of prompting
+    /// `MAX_FAILURES_BEFORE_STALL` with nothing ever confirming a delivery.
+    /// While an agent is in here the daemon leaves its cursor alone and
+    /// drops to a widening backoff instead of prompting
     /// it every tick, so the batch survives until its pane can take it — the
     /// alternative, advancing the cursor, loses those messages outright
     /// (#39).
@@ -46,7 +47,7 @@ pub struct DaemonState {
     /// an agent herdr reports no session id for has no other way out at all.
     ///
     /// Keyed by agent and never by batch: an entry that re-armed when the
-    /// batch grew would restart the five-failure cycle on every new room
+    /// batch grew would restart the run-up to the cap on every new room
     /// message, which is the redelivery loop the threshold exists to stop.
     #[serde(default)]
     pub stalled: HashMap<String, Stall>,
@@ -167,7 +168,7 @@ mod tests {
     fn a_stall_survives_a_daemon_restart() {
         // A held batch that did not outlive the daemon would be delivered
         // again on the next tick, and the agent would work back through the
-        // same five failures to reach the same stall.
+        // same run of failures to reach the same stall.
         let dir = tempfile::tempdir().unwrap();
         let mut s = DaemonState::default();
         s.cursors.insert("reviewer".into(), 7);

--- a/src/state.rs
+++ b/src/state.rs
@@ -33,8 +33,8 @@ pub struct DaemonState {
     /// Consecutive intro prompt failures per agent.
     #[serde(default)]
     pub intro_fails: HashMap<String, u32>,
-    /// Agents whose batch reached `MAX_BATCH_FAILURES` with nothing ever
-    /// confirming a delivery. While an agent is in here the daemon leaves
+    /// Agents whose batch or unconfirmed streak reached
+    /// `MAX_FAILURES_BEFORE_STALL` with nothing ever confirming a delivery. While an agent is in here the daemon leaves
     /// its cursor alone and drops to a widening backoff instead of prompting
     /// it every tick, so the batch survives until its pane can take it — the
     /// alternative, advancing the cursor, loses those messages outright


### PR DESCRIPTION
Refs #44 — part one of three. Pure refactor, no behaviour change.

`MAX_BATCH_FAILURES` gated two give-ups with two different costs:

| site | decision | cost |
|---|---|---|
| `daemon.rs` intro path | stop trying to explain the room | the agent loses its explanation of what scuttlebutt is; it still receives every batch |
| `daemon.rs` delivery path | stall and hold the batch | nothing lands at that pane until the stall lifts |

Now `MAX_INTRO_FAILURES` and `MAX_FAILURES_BEFORE_STALL`, both still `5`. They only ever coincided because both meant "enough".

## Why herd.rs is in a daemon.rs refactor

Two edits, both in one comment block the rename puts in its blast radius, kept together on purpose — splitting them across two PRs guarantees a conflict in the same lines:

1. the dangling `MAX_BATCH_FAILURES` name reference;
2. a stale claim two lines below it — the comment said the threshold "force-advances after five of those" and called the result "a bounded, logged skip". #42 (59691ce) replaced force-advancing with stall-and-hold: the cursor is held, the batch kept, delivery retries on a widening backoff, and `daemon-status` names the agent. The point survives — the cost is still bounded — for a different reason, so the comment now says what actually happens.

`state.rs` had the same shape of rot: it said the stall is reached by the batch alone, when the unconfirmed streak reaches it too.

## Deliberately not here

The value change and the pointer-on-retry, both decided in #44 and both deferred — the value waits for post-#40 data, the pointer waits behind it. #44 stays open.

## Verification

343 tests pass; `cargo fmt` and `cargo clippy --all-targets` clean.

Tests cannot catch a site pointing at the wrong constant while both are `5`, so the division was checked by moving one value at a time:

- `MAX_INTRO_FAILURES = 7`, stall `5` — 343 pass, 0 fail.
- `MAX_FAILURES_BEFORE_STALL = 7`, intro `5` — 343 pass, 0 fail.

Green is the expected result, not the absence of one: every site is keyed symbolically, so a correctly-pointed test stays self-consistent when its own constant moves. The first run of that check was **not** green — it found `a_hard_error_mid_streak_reports_the_stored_count` asserting the literal `batch 3/5, unconfirmed 2/5`, the one site pinning the cap by value rather than by name. Fixed in 5dc94c7.

A null result proves nothing on its own, so two controls, run with the constants at different values:

- intro test keyed to the stall cap → `failed_intro_gives_up_at_the_intro_cap` panics at `daemon.rs:1691`, `no entry found for key`. The loop runs to the stall cap of 7, the intro gives up at 5 and removes `intro_fails`, so the assert indexes a key that is gone.
- stall test keyed to the intro cap → `the_threshold_keeps_the_batch_and_stops_re_prompting` fails at `daemon.rs:2104`, `a stalled agent was re-prompted, left: 6 right: 5`. Five ticks never reach the stall cap of 7, so a sixth prompt goes out.

Both reverted; tree is clean at 343 passing.

## Also in the diff

Three comments spelled the cap out as the literal `5` while explaining what it gates — "`batch 6/5`", "must not log 0/5", "after five of those". None carried the constant's name, so a grep for the symbol when the value moves would have missed all three. Desensitized rather than left as a note (838371d).
