### PR TITLE
Never let a measurement decide a composer is clear

### DIFF
--- a/src/herd.rs
+++ b/src/herd.rs
@@ -226,8 +226,26 @@ fn is_rule(line: &str) -> bool {
 /// drop, and every layout this has been wrong about so far was one nobody
 /// had captured either.
 struct Regions {
-    composers: Vec<Vec<String>>,
-    others: Vec<Vec<String>>,
+    composers: Vec<Vec<Row>>,
+    others: Vec<Vec<Row>>,
+}
+
+/// One row of an identified region, in the two forms the verdict needs.
+///
+/// They differ only where a clip ran, which is `gutter_bounded`: a
+/// rule-bounded box spans the pane and is read whole, so `bare` and `text`
+/// are the same string. Where they differ, the difference is exactly what a
+/// measurement decided, which is what `composer_holds` refuses to let a row
+/// vote on.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct Row {
+    /// The row clipped to its box, its gutter or marker stripped, and
+    /// normalized. What `is_our_text` reads and what a word count measures.
+    text: String,
+    /// The same row with only its indent and its gutter or marker removed,
+    /// and no column arithmetic anywhere. Equal to `text` when the clip
+    /// took nothing off the row.
+    bare: String,
 }
 
 /// Every region of `pane` a composer could be, each as its own lines,
@@ -297,24 +315,31 @@ fn rule_bounded(lines: &[&str]) -> Regions {
         .filter(|(_, l)| is_rule(l))
         .map(|(i, _)| i)
         .collect();
-    let mut boxed: Vec<Option<(bool, Vec<String>)>> = Vec::new();
+    let mut boxed: Vec<Option<(bool, Vec<Row>)>> = Vec::new();
     for w in rules.windows(2) {
         if !same_box(lines[w[0]], lines[w[1]]) {
             boxed.push(None);
             continue;
         }
-        let mut region: Vec<String> = lines[w[0] + 1..w[1]]
+        // No clip runs here — the box spans the pane — so each row reads
+        // the same way whether or not a measurement is trusted.
+        let mut region: Vec<Row> = lines[w[0] + 1..w[1]]
             .iter()
             .map(|l| normalize(l))
             .filter(|l| !l.is_empty())
+            .map(|text| Row {
+                bare: text.clone(),
+                text,
+            })
             .collect();
         let marker = region
             .first()
-            .and_then(|first| MARKERS.iter().find(|m| first.starts_with(**m)))
+            .and_then(|first| MARKERS.iter().find(|m| first.text.starts_with(**m)))
             .map(|m| m.len());
         match marker {
             Some(marker) => {
-                region[0] = region[0][marker..].trim().to_string();
+                region[0].text = region[0].text[marker..].trim().to_string();
+                region[0].bare = region[0].text.clone();
                 boxed.push(Some((true, region)));
             }
             None if region.is_empty() => boxed.push(None),
@@ -418,6 +443,19 @@ fn boxed_row(row: &str, (start, end): (usize, usize)) -> String {
     )
 }
 
+/// The same row with its furniture stripped and nothing measured: the
+/// indent and the gutter go, the columns are left alone.
+///
+/// This is what says whether a row is empty, and whether the clip above
+/// took anything off it. Both questions have to be answerable without a
+/// measurement, because a measurement is what #47 stops a row voting on.
+fn bare_row(row: &str) -> String {
+    normalize(
+        row.trim_start()
+            .trim_start_matches(|c| GUTTERS.contains(&c)),
+    )
+}
+
 /// Every box drawn with a vertical down each of its rows and closed by a
 /// rule beneath them. OpenCode draws its composer that way and puts a
 /// single horizontal in the whole pane — the bottom edge of that box. One
@@ -439,7 +477,7 @@ fn boxed_row(row: &str, (start, end): (usize, usize)) -> String {
 /// composer is another box closed by a rule, and returning only the lowest
 /// would replace the composer with the overlay and report the batch
 /// submitted from under it.
-fn gutter_bounded(lines: &[&str]) -> Vec<Vec<String>> {
+fn gutter_bounded(lines: &[&str]) -> Vec<Vec<Row>> {
     let gutter = |l: &&str| l.trim_start().starts_with(|c| GUTTERS.contains(&c));
     let mut boxes = Vec::new();
     for (bottom, _) in lines.iter().enumerate().filter(|(_, l)| is_rule(l)) {
@@ -456,7 +494,10 @@ fn gutter_bounded(lines: &[&str]) -> Vec<Vec<String>> {
         boxes.push(
             lines[top..bottom]
                 .iter()
-                .map(|l| boxed_row(l, span))
+                .map(|l| Row {
+                    text: boxed_row(l, span),
+                    bare: bare_row(l),
+                })
                 .collect(),
         );
     }
@@ -506,11 +547,15 @@ fn composer_holds(pane: &str, sent: &str) -> Option<bool> {
         return None;
     }
     let sent = normalize(sent);
-    if composers
-        .iter()
-        .chain(&others)
-        .any(|c| is_our_text(&c.join(" "), &sent))
-    {
+    let joined = |c: &Vec<Row>| {
+        c.iter()
+            .map(|r| r.text.as_str())
+            .collect::<Vec<_>>()
+            .join(" ")
+    };
+    if composers.iter().chain(&others).any(|c| {
+        is_our_text(&joined(c), &sent)
+    }) {
         return Some(true);
     }
     // A region kept in `others` is a rule inside the box with content on
@@ -527,21 +572,30 @@ fn composer_holds(pane: &str, sent: &str) -> Option<bool> {
     // A composer showing a queue hint is showing neither our text nor a
     // clear box: the queue it names may hold our batch or may not, and
     // nothing in the pane says which.
-    if rows().any(|l| QUEUE_HINTS.iter().any(|h| l.contains(h))) {
+    if rows().any(|r| QUEUE_HINTS.iter().any(|h| r.text.contains(h))) {
         return None;
     }
-    // Non-empty but too short to tell ours from a placeholder or a menu.
-    // Per line, because a composer that draws furniture of its own below
-    // the text would otherwise carry every short line past this on the
-    // strength of the furniture's word count.
-    let classifiable = |c: &String| {
-        let words = c
+    // A row may say a composer is clear only on evidence no measurement
+    // could have manufactured. Either it is empty before any clip, span or
+    // width calculation ran, or it carries enough words to be recognized as
+    // text that is not ours *and* the clip took nothing off it, so no width
+    // calculation contributed one of those words.
+    //
+    // Per row, because a composer that draws furniture of its own below the
+    // text — OpenCode's model footer — would otherwise carry every short
+    // row past this on the strength of the furniture's word count.
+    let says_clear = |r: &Row| {
+        if r.bare.is_empty() {
+            return true;
+        }
+        let words = r
+            .text
             .trim_end_matches(['\u{2026}', '.', ' '])
             .split_whitespace()
             .count();
-        words == 0 || words >= OVERLAP_WORDS
+        words >= OVERLAP_WORDS && r.bare == r.text
     };
-    match rows().all(classifiable) {
+    match rows().all(says_clear) {
         true => Some(false),
         false => None,
     }
@@ -1002,13 +1056,21 @@ mod tests {
     }
 
     #[test]
-    fn a_clear_gutter_drawn_composer_confirms_submission() {
+    fn an_echo_in_the_composers_own_gutter_is_not_a_composer() {
         // A working lead pane carrying three transcript echoes of batches
         // it has already taken, each drawn in the same gutter as the
-        // composer. Confirming here is half the point of the fix: an echo
-        // read as a composer answers `Some(true)` on every tick, and the
-        // unconfirmed streak skips a batch just as surely as a failed
+        // composer. Identifying exactly one region is what this pins: an
+        // echo read as a composer answers `Some(true)` on every tick, and
+        // the unconfirmed streak skips a batch just as surely as a failed
         // delivery does.
+        //
+        // The verdict is `None` where this pane gave `Some(false)` before
+        // #47. Its footer row carries the working directory wrapped up the
+        // right margin, so the clip took something off the only row that
+        // could have voted, and a row a measurement had a hand in may no
+        // longer say a composer is clear —
+        // `furniture_right_aligned_over_the_composer_stops_it_confirming`
+        // is where that is argued.
         //
         // What excludes them here is that no rule is drawn beneath any of
         // them. That is a property of this pane, not a guarantee, and two
@@ -1035,22 +1097,30 @@ mod tests {
         // lowest never enters into this. That serves the opposite case, an
         // overlay drawn below a real composer.
         assert_eq!(composer_regions(OC_LIVE).composers.len(), 1);
-        assert_eq!(composer_holds(OC_LIVE, OC_SENT), Some(false));
+        assert_eq!(composer_holds(OC_LIVE, OC_SENT), None);
     }
 
     #[test]
-    fn furniture_right_aligned_over_the_composer_is_not_its_contents() {
+    fn furniture_right_aligned_over_the_composer_stops_it_confirming() {
         // Two clear composers in panes whose working directory is long
         // enough that OpenCode wraps it up the right margin, across the
         // rows the box is drawn on. `opencode-wrapped-cwd` is a live IC
         // pane, and it was found by running this locator over every pane in
-        // the fleet rather than over the captures: read as composer
-        // contents, those fragments are one word each, too short to
-        // classify, and the pane is unconfirmable for as long as its
-        // working directory is that long.
+        // the fleet rather than over the captures.
+        //
+        // The clip still keeps those fragments out of the contents: one
+        // composer is identified and its rows are what the box holds. What
+        // #47 changed is which rows may vote on that reading. A row the
+        // clip took something off had a width calculation decide part of
+        // what it says, and every batch #36 lost was that decision going
+        // wrong — a fragment kept, a short row of ours padded to three
+        // words that match nothing we sent, and a composer read as clear.
+        // So these panes confirm nothing for as long as their working
+        // directory is that long. Under #42 that holds the batch and
+        // re-prompts it rather than dropping it.
         for (name, pane) in [("an ic pane", OC_WRAPPED_CWD), ("a scratch pane", OC_EMPTY)] {
             assert_eq!(composer_regions(pane).composers.len(), 1, "{name}");
-            assert_eq!(composer_holds(pane, OC_SENT), Some(false), "{name}");
+            assert_eq!(composer_holds(pane, OC_SENT), None, "{name}");
         }
     }
 
@@ -1187,7 +1257,11 @@ mod tests {
                 .collect();
             let pane = pane.join("\n");
             assert_eq!(composer_regions(&pane).composers.len(), 1);
-            assert_eq!(composer_holds(&pane, OC_SENT), Some(false));
+            // `None` rather than a confirmation because this is built on
+            // `opencode-empty`, whose composer rows carry the wrapped
+            // working directory; the region count is what the injected
+            // rule is being tested against.
+            assert_eq!(composer_holds(&pane, OC_SENT), None);
         }
     }
 
@@ -1473,6 +1547,105 @@ mod tests {
             "\u{2500}".repeat(60)
         );
         assert_eq!(composer_holds(&pane, RULE), None);
+    }
+
+    /// One row of an OpenCode-shaped box: the gutter, the row's contents,
+    /// then whatever the pane draws up its right margin outside the box.
+    /// The box is `BOX_WIDTH` cells wide, so `margin` is what the clip is
+    /// there to remove.
+    fn gutter_row(content: &str, margin: &str) -> String {
+        let body = format!("  \u{2503}  {content}");
+        format!(
+            "{body}{}{margin}",
+            " ".repeat(BOX_WIDTH - display_width(&body))
+        )
+    }
+
+    fn gutter_box(rows: &[String]) -> String {
+        let mut lines = rows.to_vec();
+        lines.push("\u{2500}".repeat(BOX_WIDTH));
+        lines.push("  status".into());
+        lines.join("\n")
+    }
+
+    const BOX_WIDTH: usize = 60;
+
+    /// Every identified composer's rows as the clip leaves them.
+    fn texts(pane: &str) -> Vec<Vec<String>> {
+        composer_regions(pane)
+            .composers
+            .iter()
+            .map(|c| c.iter().map(|r| r.text.clone()).collect())
+            .collect()
+    }
+
+    #[test]
+    fn a_row_the_clip_left_alone_reads_the_same_either_way() {
+        // `bare_row` and `boxed_row` strip the same furniture off the same
+        // row and have to do it the same way, so that the only thing left
+        // between them is the clip. Two functions reading one row two ways
+        // is #36's two-metrics defect one function over, and here it would
+        // be silent in the expensive direction: every row would read as one
+        // the clip had touched, and no gutter-drawn composer could confirm
+        // anything again.
+        let span = box_span(&"\u{2500}".repeat(BOX_WIDTH));
+        for row in [
+            "  \u{2503}",
+            "  \u{2503}  Reply only",
+            "    \u{2503}  indented further than its own closing rule",
+            "  \u{2503}  Build \u{b7} GPT-5.6 Sol OpenAI",
+        ] {
+            assert_eq!(bare_row(row), boxed_row(row, span), "{row:?}");
+        }
+    }
+
+    #[test]
+    fn a_row_the_clip_touched_cannot_say_a_composer_is_clear() {
+        // The measurement layer's actual mechanism, from #36: the clip kept
+        // a fragment of the right margin, which padded a row up to a word
+        // count that reads as text long enough to be recognized as not
+        // ours — and a composer holding only text that is not ours is a
+        // composer we call clear. Whether the clip got those columns right
+        // or wrong, a row it took something off is a row whose word count
+        // a width calculation had a hand in, so it may not cast that vote.
+        let footer = "Build \u{b7} GPT-5.6 Sol OpenAI";
+        let clean = gutter_box(&[
+            gutter_row("", ""),
+            gutter_row("", ""),
+            gutter_row(footer, ""),
+        ]);
+        let overlapped = gutter_box(&[
+            gutter_row("", ""),
+            gutter_row("", ""),
+            gutter_row(footer, "~/dev/alare:main"),
+        ]);
+        // Identical inside the box: the clip removes the difference, and
+        // what is left is the same rows read the same way.
+        assert_eq!(texts(&clean), texts(&overlapped));
+        assert_eq!(composer_holds(&clean, RULE), Some(false));
+        assert_eq!(composer_holds(&overlapped, RULE), None);
+    }
+
+    #[test]
+    fn a_row_blank_only_after_clipping_is_not_an_empty_row() {
+        // The other half of the same rule. An empty row is the evidence
+        // that a composer is clear, so it has to be evidence no clip, span
+        // or width calculation could have manufactured: the row is empty
+        // only if it is empty before any of them ran.
+        let footer = "Build \u{b7} GPT-5.6 Sol OpenAI";
+        let clean = gutter_box(&[
+            gutter_row("", ""),
+            gutter_row("", ""),
+            gutter_row(footer, ""),
+        ]);
+        let overlapped = gutter_box(&[
+            gutter_row("", "~/dev/alare:main"),
+            gutter_row("", "~/dev/alare:main"),
+            gutter_row(footer, ""),
+        ]);
+        assert_eq!(texts(&clean), texts(&overlapped));
+        assert_eq!(composer_holds(&clean, RULE), Some(false));
+        assert_eq!(composer_holds(&overlapped, RULE), None);
     }
 
     // ---- nothing identified is never a confirmation ---------------------

--- a/src/herd.rs
+++ b/src/herd.rs
@@ -370,8 +370,11 @@ fn rule_bounded(lines: &[&str]) -> Regions {
 /// composer is drawn on — and clipping to the box is what keeps that out of
 /// the composer's contents. Left in, it reads as text that is not ours: a
 /// two-word unsubmitted prompt with a fragment of a path beside it is three
-/// words, which is no longer too short to classify, which is `Some(false)`
-/// and the batch gone.
+/// words, which is no longer too short to classify. That was `Some(false)`
+/// and the batch gone, which is how every batch #36 lost was lost; since #47
+/// a row this clipped anything off may not cast that vote either way, so
+/// getting these columns wrong costs a repeat rather than the batch. The
+/// clip still has to be right — it is what the contents *are*.
 ///
 /// Columns are display cells rather than characters, because that is what
 /// the pane was drawn in. Counting characters clips a row carrying a
@@ -398,7 +401,9 @@ fn box_span(border: &str) -> (usize, usize) {
 /// so `\u{26a0}\u{fe0f}\u{fe0f}` measures three where a terminal draws two. Left alone
 /// deliberately: over-counting a row clips it early, which can only shorten
 /// what a composer is read as holding, and shortening is the direction that
-/// costs a repeat rather than a batch.
+/// costs a repeat rather than a batch. Since #47 it costs even less — a row
+/// the clip shortened is a row a measurement touched, so it may not say the
+/// composer is clear at all, whichever direction the error ran.
 fn cell_width(c: char, previous: usize) -> usize {
     match c {
         '\u{fe0f}' => usize::from(previous == 1),
@@ -418,7 +423,9 @@ fn display_width(s: &str) -> usize {
 }
 
 /// One row of a gutter-bounded box, clipped to the box's columns, gutter
-/// stripped and normalized.
+/// stripped and normalized. `bare_row` is the same row with the same
+/// furniture stripped and no clip, and the two differ exactly where a
+/// measurement had a hand in the row.
 fn boxed_row(row: &str, (start, end): (usize, usize)) -> String {
     let mut col = 0;
     let mut previous = 0;
@@ -528,8 +535,13 @@ fn is_our_text(content: &str, sent: &str) -> bool {
 ///
 /// `Some(false)` — submitted — is the only answer that advances a cursor and
 /// so the only one that can lose a batch, and it is reachable on exactly one
-/// path: at least one composer was identified, and every identified composer
-/// is either empty or holds text long enough to be recognized as not ours.
+/// path: at least one composer was identified, and every one of its rows says
+/// so on evidence no measurement produced. A row says so by being empty
+/// before any clip, span or width calculation ran, or by carrying enough
+/// words to be recognized as text that is not ours while the clip took
+/// nothing off it. That is #47: a clip, a span or a width calculation cannot
+/// manufacture the evidence of a clear composer, because neither thing a row
+/// may vote on is anything they had a hand in.
 /// Everything else is `None`, including cases that look like nothing at all:
 /// no composer identified in either layout, a marker we do not know, a
 /// queue hint standing in for the composer's contents, or content too short
@@ -541,6 +553,20 @@ fn is_our_text(content: &str, sent: &str) -> bool {
 /// three review rounds found layouts nobody anticipated, and each one was a
 /// case that failed to match and fell through to `Submitted`. There is no
 /// fall-through here — a layout this does not understand cannot reach it.
+///
+/// What #47 costs, measured rather than guessed: an OpenCode pane whose
+/// working directory wraps up the right margin across the box's rows can no
+/// longer confirm anything, because the clip takes that fragment off a row
+/// which then may not vote. Three captures are in that state
+/// (`opencode-empty`, `opencode-live-room`, `opencode-wrapped-cwd`) and no
+/// live pane was at the time of the change. Under #42 that holds the batch
+/// and re-prompts it rather than dropping it.
+///
+/// A composer carrying text that is merely *someone else's* — a human
+/// typing, OpenCode's `Ask anything...` hint — still confirms. #47 proposed
+/// closing that too; it was deliberately left open, because none of the four
+/// batches #36 lost went that way and closing it would stall every pane a
+/// human is typing in for no measured safety.
 fn composer_holds(pane: &str, sent: &str) -> Option<bool> {
     let Regions { composers, others } = composer_regions(pane);
     if composers.is_empty() {
@@ -553,9 +579,11 @@ fn composer_holds(pane: &str, sent: &str) -> Option<bool> {
             .collect::<Vec<_>>()
             .join(" ")
     };
-    if composers.iter().chain(&others).any(|c| {
-        is_our_text(&joined(c), &sent)
-    }) {
+    if composers
+        .iter()
+        .chain(&others)
+        .any(|c| is_our_text(&joined(c), &sent))
+    {
         return Some(true);
     }
     // A region kept in `others` is a rule inside the box with content on
@@ -968,7 +996,10 @@ mod tests {
     fn every_real_pane_identifies_a_composer() {
         // #36 in one assertion: none of these identified anything, so every
         // delivery to them was unconfirmable and the failure threshold
-        // skipped the batch after five tries.
+        // skipped the batch after five tries. That was then — #42 replaced
+        // skipping with stall-and-hold, so an unconfirmable pane now holds
+        // its batch and re-prompts it on a widening wait (#39). Five is the
+        // historical number and stays five here whatever the constant does.
         for (name, pane) in [
             ("claude code, titled border", TITLED),
             ("claude code, plain border", EMPTY),
@@ -1129,6 +1160,13 @@ mod tests {
         // OpenCode's own `Ask anything...` hint, unlike a queue hint, is
         // shown *because* there is nothing to show: no queue stands behind
         // it, so a batch that reached the pane is not in one.
+        //
+        // This pane still confirms where the other three OpenCode captures
+        // no longer do, and the difference is not the hint: nothing on this
+        // box's rows is clipped, so every row still says what it says
+        // without a measurement. #47 proposed making a composer carrying
+        // someone else's text `None` as well; that half was deliberately
+        // not done, so the hint reads exactly as it did before.
         assert_eq!(composer_holds(OC_HINT, OC_SENT), Some(false));
     }
 

--- a/src/herd.rs
+++ b/src/herd.rs
@@ -1627,14 +1627,22 @@ mod tests {
         // be silent in the expensive direction: every row would read as one
         // the clip had touched, and no gutter-drawn composer could confirm
         // anything again.
-        let span = box_span(&"\u{2500}".repeat(BOX_WIDTH));
-        for row in [
-            "  \u{2503}",
-            "  \u{2503}  Reply only",
-            "    \u{2503}  indented further than its own closing rule",
-            "  \u{2503}  Build \u{b7} GPT-5.6 Sol OpenAI",
-        ] {
-            assert_eq!(bare_row(row), boxed_row(row, span), "{row:?}");
+        // Both spans the code meets, and the indented one is the shape
+        // every capture has: a rule that starts at column 2 clips into the
+        // row's own indent, which is where the two could diverge and the
+        // flush case never reaches.
+        let flush = box_span(&"\u{2500}".repeat(BOX_WIDTH));
+        let indented = box_span(&format!("  {}", "\u{2500}".repeat(BOX_WIDTH - 2)));
+        assert_eq!((flush.0, indented.0), (0, 2), "spans lost their indents");
+        for span in [indented, flush] {
+            for row in [
+                "  \u{2503}",
+                "  \u{2503}  Reply only",
+                "    \u{2503}  indented further than its own closing rule",
+                "  \u{2503}  Build \u{b7} GPT-5.6 Sol OpenAI",
+            ] {
+                assert_eq!(bare_row(row), boxed_row(row, span), "{span:?} {row:?}");
+            }
         }
     }
 

--- a/src/herd.rs
+++ b/src/herd.rs
@@ -1270,9 +1270,10 @@ mod tests {
         // walks up from it and boxes the echo above as a composer — holding
         // the batch it quotes, on every tick, forever.
         //
-        // That is why `a_clear_gutter_drawn_composer_confirms_submission`
-        // could not carry the guarantee on its own: "no rule is drawn beneath
-        // an echo" is false for any message body containing one.
+        // That is why `an_echo_in_the_composers_own_gutter_is_not_a_composer`
+        // could not carry the guarantee on its own: it rests on "no rule is
+        // drawn beneath an echo", which is a property of that one capture
+        // and false for any message body containing one.
         let separator = format!("  \u{2503}  \u{251c}{}\u{2524}", "\u{2500}".repeat(16));
         let plain = format!("  \u{2503}  {}", "\u{2500}".repeat(16));
         // Two guards keep those out, and each has a shape only it catches.


### PR DESCRIPTION
Refs #47.

`Some(false)` is the only verdict that advances a delivery cursor, so it is the only one that can lose a batch. This narrows what may reach it: **a row may say a composer is clear only on evidence no measurement produced.** Either the row is empty *before* any clip, span or width calculation ran, or it carries enough words to be recognized as text that is not ours *and* the clip took nothing off it.

Regions now carry each row in both forms — `text` as the clip leaves it, `bare` with only the indent and the gutter or marker removed — and the two are equal exactly when no measurement had a hand in the row.

Every existing guard stays: `same_box`, the adjacency filter on `others`, the `others` veto, and the single `cell_width` metric. This narrows what may conclude "clear"; it does not change how regions are found.

## The issue's stated mechanism is wrong, and that changed the fix

#47 argues that "a measurement error can turn a row that HAD our text on it into an empty one, and an empty row is what we read as a cleared composer," and proposes requiring the **raw** row to be blank.

That is not how any of the four batch-losing defects happened. #40's own PR body records the mechanism:

> The pane's own right-aligned furniture (a long working directory wrapped up the right margin, across the box's rows) is clipped off by the columns of the bottom edge that closes the box: **nothing the composer draws lies outside its own box, so the clip cannot empty a row that had our text on it.**

and, on `box_span`:

> Left in, it reads as text that is not ours: a two-word unsubmitted prompt with a fragment of a path beside it is three words, which is no longer too short to classify, which is `Some(false)` and the batch gone.

So the clip **kept** furniture, which padded a short row of ours up to three words that match nothing we sent, so the row voted "not ours" and the composer read as clear. Same shape for `box_span`-in-characters and for the two-metrics defect. Only the footer pop ever emptied a row, and that was a structural pop, not a width calculation.

The class #47 closes by requiring raw-blankness is therefore not the class that produced the drops. The class that did is closed by the clip-clean rule alone, which is smaller and does not carry the cost below.

## Why the issue's literal rule was not implemented

Removing the "long enough to be recognized as not ours" branch outright makes **every OpenCode pane unconfirmable by construction**. OpenCode draws a model footer (`┃  Build · GPT-5.6 Sol OpenAI`) inside the composer box on every capture we have. It is never blank, raw or clipped, and today it passes only through the branch #47 removes. So no OpenCode composer can ever be all-empty, and none can ever confirm.

That is worse than the drop being removed, and it is not the bounded stall #47 trades for. `MAX_STALL_RETRY_TICKS` caps `retry_after` at 900 ticks, so the failure is not an unbounded backoff decaying toward silence — it is **the same batch held forever and re-prompted every ~30 minutes forever, on every pane of that agent kind, visible only in `daemon-status`**. A permanent low-grade duplicator.

**Do not reach for the obvious workaround.** Exempting the last row of a gutter box is the defect #40 removed: `a_gutter_box_without_a_footer_still_holds_what_is_in_it` pins `["", "", "Reply only"]` as `None`, and exempting that row flips it to `Some(false)` and eats a two-word prompt.

## Numbers

Variants measured over the 13 checked-in fixtures and a live sweep of every pane in `herdr agent list` (7 named, 4 of them OpenCode), before the change was written:

| rule | live panes confirming (of 7) | OpenCode live confirming (of 4) | OpenCode clear fixtures → `None` |
|---|---|---|---|
| current | 6 | 3 | — |
| #47 literal (every row empty, raw) | 3 | 0 | 4 |
| literal + positional footer exemption | 6 | 3 | 1 — but reintroduces #36's footer pop |
| clip-clean vote (this PR) | 6 | 3 | 3 |

Judging emptiness on the raw row and on the clipped row give **identical verdicts on all 13 fixtures and all 7 live panes** — the footer blocks every case before raw-ness is reached — so the half #47 names as the mechanism is a no-op on everything we have, while the half that bites is the one whose cost the issue does not name.

Re-swept with the final code, over a fresh capture of the fleet:

| | before | after |
|---|---|---|
| fixtures confirming | 7 | 4 |
| fixtures changed | — | 3, all `Some(false)` → `None` |
| live panes confirming (of 7) | 6 | 6 |
| live panes changed | — | 0 |

The three fixtures are `opencode-empty`, `opencode-live-room` and `opencode-wrapped-cwd`. Each has its working directory wrapped up the right margin across the box's rows, so the clip takes a fragment off the one row that could have voted. No live pane was in that state at the time of the change; the shape is real and recurs whenever a pane's cwd is long enough, and #40 found it by sweeping the fleet rather than the captures.

The four fixture assertions changed are pinned to the new actual value with `assert_eq!`, none weakened to `assert_ne!`. The fourth is `a_rule_inside_a_gutter_row_does_not_box_the_transcript`, which is built on `opencode-empty` and tracks it; its own subject, the region count, is unchanged. `no_real_pane_holding_a_batch_reports_it_submitted` keeps its `assert_ne!` — it is the safety invariant "never `Some(false)`", not a pinned value.

## What is deliberately left undone

#47 also asks that a composer carrying **someone else's** text become `None` — a human typing, OpenCode's `Ask anything...` hint. **Not done, and not bundled.** None of the four batches #36 lost went that way, so it buys no measured safety, and it would stall every pane a human is typing in. It needs its own argument and its own evidence. #47 stays open for it; that is why this is `Refs`, not `Closes`.

## Verification

- `cargo test` — **346 passed / 0 failed**, up from 343. `cargo fmt --check` and `cargo clippy --all-targets` clean.
- Three new tests, each watched fail first, each pinning a distinct line:
  - `a_row_the_clip_touched_cannot_say_a_composer_is_clear` — dies, alone, when the `bare == text` conjunct is dropped.
  - `a_row_blank_only_after_clipping_is_not_an_empty_row` — dies, alone, when emptiness is judged on the clipped row.
  - `a_row_the_clip_left_alone_reads_the_same_either_way` — `bare_row` and `boxed_row` must strip identical furniture, so the only thing between them is the clip. Two functions reading one row two ways is #36's two-metrics defect one function over, and here it fails silently in the expensive direction.
- Seven mutations run, all red. Reverting the whole rule to its pre-#47 form kills exactly five assertions — the three new tests and the two fixture tests — which is the change's entire blast radius.
- Grepped the class rather than the instance: `Some(false)` has exactly one production site in the crate (`src/herd.rs:627`), and every other clipped-value decision (`is_our_text`, the queue-hint check, marker detection, `same_box`) resolves toward `None` or `Some(true)`, both of which cost a repeat.

## Comments

`composer_holds`, `box_span` and `cell_width` each justified themselves by what `Some(false)` used to be reachable from, which is precisely the rule this replaces; all three are rewritten. `every_real_pane_identifies_a_composer` stated a true fact about the past — the threshold skipped the batch after five tries — in a tense that reads as present, which #42 made false. Its tense is fixed and the five is kept: it is history, not a constant.

No version bump. The daemon runs the installed build, so this needs a release and a reinstall before it takes effect.
