### PR TITLE
Derive the groups listing and rooms from one union

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,6 +3,7 @@ use crate::groups::{self, CurrentRoom, Grouping};
 use crate::herd::{AgentInfo, HerdControl};
 use crate::log_store::{self, Message};
 use anyhow::{bail, Result};
+use std::fmt::Write as _;
 use std::path::Path;
 
 /// Which room this invocation talks to: a configured prefix, else the repo's
@@ -109,55 +110,95 @@ pub fn visible_agents<'a>(
 
 pub fn cmd_groups(herd: &dyn HerdControl) -> Result<()> {
     let grouping = current_grouping()?;
-    if let Grouping::Broken(msg) = &grouping {
-        println!("groups config BROKEN — no agent is enrolled: {msg}");
-        return Ok(());
+    // Not asked for under `Broken`: the listing names no agent there, so a
+    // round trip to herdr could only produce a roster we would not print.
+    let agents = match grouping {
+        Grouping::Broken(_) => Ok(Vec::new()),
+        _ => herd.list_agents().map_err(|e| e.to_string()),
+    };
+    let mut orgs = OrgCache::default();
+    print!(
+        "{}",
+        render_groups(
+            &grouping,
+            agents.as_deref().map_err(String::as_str),
+            &mut orgs
+        )
+    );
+    Ok(())
+}
+
+/// The `groups` listing as text, so every shape of it can be asserted on.
+/// `current_grouping` reads a fixed path and the roster comes from a live
+/// herdr, so the three shapes that carry the most logic — a group named by no
+/// config, agents the config enrolls nowhere, and a herd that will not answer
+/// — are unreachable through `cmd_groups` itself. The real config on this
+/// machine produces none of them.
+///
+/// `agents` carries the listing failure rather than an empty roster because
+/// the two print differently: telling "nobody is enrolled" apart from "I could
+/// not ask" is what this auditing surface is for.
+fn render_groups(
+    grouping: &Grouping,
+    agents: std::result::Result<&[AgentInfo], &str>,
+    orgs: &mut OrgCache,
+) -> String {
+    // Writing to a String cannot fail, hence the discarded results throughout.
+    let mut out = String::new();
+    if let Grouping::Broken(msg) = grouping {
+        let _ = writeln!(out, "groups config BROKEN — no agent is enrolled: {msg}");
+        return out;
     }
-    match &grouping {
-        Grouping::Inactive => {
-            println!("no groups.toml — each agent's group is its repository's origin organization")
-        }
-        _ => println!("groups.toml rules first, then each agent's repository origin"),
-    }
-    let agents = match herd.list_agents() {
+    let _ = match grouping {
+        Grouping::Inactive => writeln!(
+            out,
+            "no groups.toml — each agent's group is its repository's origin organization"
+        ),
+        _ => writeln!(
+            out,
+            "groups.toml rules first, then each agent's repository origin"
+        ),
+    };
+    let agents: &[AgentInfo] = match agents {
         Ok(a) => a,
         Err(e) => {
             // Distinguish "nobody is enrolled" from "I could not ask": this is
             // the auditing surface, and an empty roster that really means herdr
             // is down must not read as isolation.
-            println!(
+            let _ = writeln!(
+                out,
                 "cannot list agents ({e}) — membership below is unknown; \
                  only the configured prefixes are shown"
             );
-            Vec::new()
+            &[]
         }
     };
-    let mut orgs = OrgCache::default();
     let mut members: std::collections::BTreeMap<Option<String>, Vec<&AgentInfo>> =
         std::collections::BTreeMap::new();
-    for a in &agents {
+    for a in agents {
         members
-            .entry(groups::resolve(Path::new(&a.cwd), &grouping, &mut orgs))
+            .entry(groups::resolve(Path::new(&a.cwd), grouping, orgs))
             .or_default()
             .push(a);
     }
     let print_members =
-        |name: &Option<String>,
+        |out: &mut String,
+         name: &Option<String>,
          members: &std::collections::BTreeMap<Option<String>, Vec<&AgentInfo>>| {
             for a in members.get(name).unwrap_or(&Vec::new()) {
-                println!("  {}\t{}\t{}", a.name, a.status, a.cwd);
+                let _ = writeln!(out, "  {}\t{}\t{}", a.name, a.status, a.cwd);
             }
         };
     let mut configured: Vec<String> = Vec::new();
-    if let Grouping::Active(rules) = &grouping {
+    if let Grouping::Active(rules) = grouping {
         for name in rules.names() {
             let paths: Vec<String> = rules
                 .prefixes_for(name)
                 .iter()
                 .map(|p| p.display().to_string())
                 .collect();
-            println!("{name}\t{}", paths.join(" "));
-            print_members(&Some(name.to_string()), &members);
+            let _ = writeln!(out, "{name}\t{}", paths.join(" "));
+            print_members(&mut out, &Some(name.to_string()), &members);
             configured.push(name.to_string());
         }
     }
@@ -167,19 +208,21 @@ pub fn cmd_groups(herd: &dyn HerdControl) -> Result<()> {
         if configured.iter().any(|c| c == name) {
             continue;
         }
-        println!("{name}\t(from repo origin)");
-        print_members(&Some(name.clone()), &members);
+        let _ = writeln!(out, "{name}\t(from repo origin)");
+        print_members(&mut out, &Some(name.clone()), &members);
     }
     if let Some(ungrouped) = members.get(&None) {
-        match grouping {
-            Grouping::Inactive => println!("ungrouped (shared room — no repository origin)"),
-            _ => println!("ungrouped (receiving nothing)"),
-        }
+        let _ = match grouping {
+            Grouping::Inactive => {
+                writeln!(out, "ungrouped (shared room — no repository origin)")
+            }
+            _ => writeln!(out, "ungrouped (receiving nothing)"),
+        };
         for a in ungrouped {
-            println!("  {}\t{}\t{}", a.name, a.status, a.cwd);
+            let _ = writeln!(out, "  {}\t{}\t{}", a.name, a.status, a.cwd);
         }
     }
-    Ok(())
+    out
 }
 
 /// The rooms this session could open. Not scoped to the caller's group:
@@ -736,6 +779,85 @@ mod tests {
         assert_eq!(
             format_messages(&msgs),
             "[#3 2026-08-18T12:00:00+00:00] reviewer: done\n"
+        );
+    }
+
+    /// Adds the shapes the real config cannot produce: an agent whose repo
+    /// origin names a group no config does, and an agent under no repo at all.
+    fn mixed_agents() -> Vec<AgentInfo> {
+        let mut v = grouped_agents();
+        v.push(AgentInfo {
+            name: "beta-1".into(),
+            pane_id: "w4:p1".into(),
+            status: "working".into(),
+            cwd: "/w/beta/api".into(),
+            focused: Some(false),
+            session: None,
+        });
+        v
+    }
+
+    #[test]
+    fn a_broken_config_says_so_rather_than_listing_nothing() {
+        let out = render_groups(
+            &Grouping::Broken("bad toml".into()),
+            Ok(&mixed_agents()),
+            &mut orgs(fake_org),
+        );
+        assert_eq!(
+            out,
+            "groups config BROKEN — no agent is enrolled: bad toml\n"
+        );
+    }
+
+    #[test]
+    fn configured_groups_come_before_org_derived_ones_with_their_members() {
+        let out = render_groups(&active(), Ok(&mixed_agents()), &mut orgs(fake_org));
+        assert_eq!(
+            out,
+            "groups.toml rules first, then each agent's repository origin\n\
+             acme\t/w/acme\n  \
+             acme-secret-issue\tidle\t/w/acme/web\n\
+             alare\t/w/alare\n  \
+             issue-590\tidle\t/w/alare/api\n\
+             beta\t(from repo origin)\n  \
+             beta-1\tworking\t/w/beta/api\n\
+             ungrouped (receiving nothing)\n  \
+             stray\tidle\t/tmp/scratch\n"
+        );
+    }
+
+    #[test]
+    fn without_a_config_every_group_is_an_org_and_ungrouped_is_the_shared_room() {
+        let out = render_groups(
+            &Grouping::Inactive,
+            Ok(&mixed_agents()),
+            &mut orgs(fake_org),
+        );
+        assert_eq!(
+            out,
+            "no groups.toml — each agent's group is its repository's origin organization\n\
+             acme\t(from repo origin)\n  \
+             acme-secret-issue\tidle\t/w/acme/web\n\
+             alare\t(from repo origin)\n  \
+             issue-590\tidle\t/w/alare/api\n\
+             beta\t(from repo origin)\n  \
+             beta-1\tworking\t/w/beta/api\n\
+             ungrouped (shared room — no repository origin)\n  \
+             stray\tidle\t/tmp/scratch\n"
+        );
+    }
+
+    #[test]
+    fn a_herd_that_will_not_answer_still_prints_the_configured_prefixes() {
+        let out = render_groups(&active(), Err("herdr not running"), &mut orgs(fake_org));
+        assert_eq!(
+            out,
+            "groups.toml rules first, then each agent's repository origin\n\
+             cannot list agents (herdr not running) — membership below is unknown; \
+             only the configured prefixes are shown\n\
+             acme\t/w/acme\n\
+             alare\t/w/alare\n"
         );
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -173,23 +173,18 @@ fn render_groups(
             &[]
         }
     };
-    let mut members: std::collections::BTreeMap<Option<String>, Vec<&AgentInfo>> =
-        std::collections::BTreeMap::new();
-    for a in agents {
-        members
-            .entry(groups::resolve(Path::new(&a.cwd), grouping, orgs))
-            .or_default()
-            .push(a);
-    }
-    let print_members =
-        |out: &mut String,
-         name: &Option<String>,
-         members: &std::collections::BTreeMap<Option<String>, Vec<&AgentInfo>>| {
-            for a in members.get(name).unwrap_or(&Vec::new()) {
-                let _ = writeln!(out, "  {}\t{}\t{}", a.name, a.status, a.cwd);
-            }
-        };
-    let mut configured: Vec<String> = Vec::new();
+    // `Broken` returned above with its own message, and it is the only
+    // grouping without a union, so this default never fires from here. The
+    // early-out is what keeps a config we could not parse from printing as an
+    // empty roster; this is belt and braces behind it.
+    let members = groups::memberships(grouping, agents, orgs).unwrap_or_default();
+    let print_members = |out: &mut String, m: Option<&groups::Membership>| {
+        for a in m.map(|m| m.agents.as_slice()).unwrap_or_default() {
+            let _ = writeln!(out, "  {}\t{}\t{}", a.name, a.status, a.cwd);
+        }
+    };
+    // Two passes, not one over the map: every configured group prints before
+    // any org-derived one, and a single pass would interleave them by name.
     if let Grouping::Active(rules) = grouping {
         for name in rules.names() {
             let paths: Vec<String> = rules
@@ -198,19 +193,25 @@ fn render_groups(
                 .map(|p| p.display().to_string())
                 .collect();
             let _ = writeln!(out, "{name}\t{}", paths.join(" "));
-            print_members(&mut out, &Some(name.to_string()), &members);
-            configured.push(name.to_string());
+            print_members(&mut out, members.get(&Some(name.to_string())));
         }
     }
     // Groups nothing in the config names: they exist because an agent's repo
     // points at that organization, and they appear and vanish with the agents.
-    for name in members.keys().flatten() {
-        if configured.iter().any(|c| c == name) {
+    // `configured` is the union's record of which groups the config names,
+    // which is what the pass above walked, so the two passes cannot disagree
+    // about where the boundary between them falls.
+    for (name, m) in &members {
+        let (Some(name), false) = (name, m.configured) else {
             continue;
-        }
+        };
         let _ = writeln!(out, "{name}\t(from repo origin)");
-        print_members(&mut out, &Some(name.clone()), &members);
+        print_members(&mut out, Some(m));
     }
+    // The union keys agents that resolve nowhere under `None` whatever the
+    // grouping. Under a config that is a diagnostic — those agents receive
+    // nothing — which is why this listing shows it where `groups::rooms`,
+    // enumerating rooms you can open, drops it.
     if let Some(ungrouped) = members.get(&None) {
         let _ = match grouping {
             Grouping::Inactive => {
@@ -218,9 +219,7 @@ fn render_groups(
             }
             _ => writeln!(out, "ungrouped (receiving nothing)"),
         };
-        for a in ungrouped {
-            let _ = writeln!(out, "  {}\t{}\t{}", a.name, a.status, a.cwd);
-        }
+        print_members(&mut out, Some(ungrouped));
     }
     out
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -826,6 +826,50 @@ mod tests {
         );
     }
 
+    /// The shape every other fixture hides. Both passes emit sorted names, so
+    /// a config naming `acme` and `alare` prints identically whether the
+    /// passes are separate or folded into one walk of the map — only a
+    /// configured name that sorts *after* an org-derived one can tell them
+    /// apart, and the real config has none.
+    #[test]
+    fn a_configured_group_prints_first_even_when_its_name_sorts_last() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("groups.toml"),
+            "[groups]\nzulu = [\"/w/zulu\"]\n",
+        )
+        .unwrap();
+        let g = crate::groups::load(dir.path());
+        std::mem::forget(dir);
+        let agents = vec![
+            AgentInfo {
+                name: "acme-1".into(),
+                pane_id: "w1:p1".into(),
+                status: "idle".into(),
+                cwd: "/w/acme/web".into(),
+                focused: Some(false),
+                session: None,
+            },
+            AgentInfo {
+                name: "zulu-1".into(),
+                pane_id: "w2:p1".into(),
+                status: "idle".into(),
+                cwd: "/w/zulu/api".into(),
+                focused: Some(false),
+                session: None,
+            },
+        ];
+        let out = render_groups(&g, Ok(&agents), &mut orgs(fake_org));
+        assert_eq!(
+            out,
+            "groups.toml rules first, then each agent's repository origin\n\
+             zulu\t/w/zulu\n  \
+             zulu-1\tidle\t/w/zulu/api\n\
+             acme\t(from repo origin)\n  \
+             acme-1\tidle\t/w/acme/web\n"
+        );
+    }
+
     #[test]
     fn without_a_config_every_group_is_an_org_and_ungrouped_is_the_shared_room() {
         let out = render_groups(

--- a/src/groups.rs
+++ b/src/groups.rs
@@ -307,8 +307,10 @@ fn has_history(dir: &Path) -> bool {
 }
 
 /// The accumulating entry for one room name, created blank on first touch.
-/// Every source goes through this, which is what makes the union a dedup
-/// rather than three lists concatenated.
+/// Only the session-directory sweep reaches for this now — the config and the
+/// live roster are already deduped against each other by `memberships`, and
+/// this is what folds the third source into that same map rather than
+/// concatenating a second list onto it.
 fn entry_for(found: &mut BTreeMap<Option<String>, Room>, name: Option<String>) -> &mut Room {
     found.entry(name.clone()).or_insert(Room {
         name,
@@ -318,48 +320,103 @@ fn entry_for(found: &mut BTreeMap<Option<String>, Room>, name: Option<String>) -
     })
 }
 
+/// One room's membership as the config and the live roster see it. These are
+/// the two sources `rooms` and the `groups` listing both derive from, and
+/// deriving them twice is what let the two commands disagree about which
+/// rooms exist. The session-directory sweep is `rooms`' third source and is
+/// deliberately not here: a room surviving only as history has no membership
+/// to hold, and sweeping the disk on the `groups` path would mean listing
+/// rooms the config never named.
+#[derive(Debug, Default)]
+pub struct Membership<'a> {
+    /// Named by `groups.toml`.
+    pub configured: bool,
+    /// Live agents whose cwd resolves here, in the order the roster gave them.
+    /// `rooms` wants only the count; the `groups` listing prints each one.
+    pub agents: Vec<&'a crate::herd::AgentInfo>,
+}
+
+/// Every room the config names or a live agent stands in, keyed by group name
+/// with `None` for the ungrouped room. The `None` key holds agents that
+/// resolve nowhere under *any* grouping — that bucket means "receiving
+/// nothing" under an active config and "the single shared room" without one,
+/// and the two callers want it read differently, so the split stays with
+/// them.
+///
+/// `None` for the whole map under `Broken`, and the two callers lean on that
+/// differently. `rooms` has no other refusal: it returns on this `None`, and
+/// deleting the guard would carry it past the config into the disk sweep,
+/// which never reads the config and would list every company's room. The
+/// `groups` listing refuses `Broken` above with its own message, so the arm
+/// is unreachable from there and is belt and braces behind that early-out.
+pub fn memberships<'a>(
+    grouping: &Grouping,
+    agents: &'a [crate::herd::AgentInfo],
+    orgs: &mut crate::git_org::OrgCache,
+) -> Option<BTreeMap<Option<String>, Membership<'a>>> {
+    if matches!(grouping, Grouping::Broken(_)) {
+        return None;
+    }
+    let mut found: BTreeMap<Option<String>, Membership<'a>> = BTreeMap::new();
+    if let Grouping::Active(rules) = grouping {
+        for name in rules.names() {
+            found.entry(Some(name.to_string())).or_default().configured = true;
+        }
+    }
+    for a in agents {
+        found
+            .entry(resolve(Path::new(&a.cwd), grouping, orgs))
+            .or_default()
+            .agents
+            .push(a);
+    }
+    Some(found)
+}
+
 /// Every room this session could open, deduped across the three sources that
 /// know about rooms and genuinely disagree: the config, the live agents, and
 /// the session directory. In a real config `jackdaw` is configured with no
 /// room file and `andybarilla` has 42 KB of history and appears in no config,
 /// so no one source is the list.
 ///
-/// `Broken` yields nothing, mirroring `visible_agents`. The disk sweep below
-/// never consults the config, so enumerating under a config we could not
-/// parse would list every company's room — the outcome this module exists to
-/// prevent.
+/// The first two come from `memberships`, shared with the `groups` listing so
+/// the two commands cannot drift about which rooms exist. The session
+/// directory is this function's own source.
+///
+/// `Broken` yields nothing, mirroring `visible_agents`: `memberships` builds
+/// no union there and this returns on that rather than falling through. The
+/// disk sweep below never consults the config, so reaching it under a config
+/// we could not parse would list every company's room — the outcome this
+/// module exists to prevent.
 pub fn rooms(
     grouping: &Grouping,
     agents: &[crate::herd::AgentInfo],
     session_dir: &Path,
     orgs: &mut crate::git_org::OrgCache,
 ) -> Vec<Room> {
-    if matches!(grouping, Grouping::Broken(_)) {
-        return Vec::new();
-    }
-    let mut found: BTreeMap<Option<String>, Room> = BTreeMap::new();
-
-    if let Grouping::Active(rules) = grouping {
-        for name in rules.names() {
-            entry_for(&mut found, Some(name.to_string())).configured = true;
-        }
-    }
-
-    for a in agents {
-        match resolve(Path::new(&a.cwd), grouping, orgs) {
-            Some(g) => entry_for(&mut found, Some(g)).agents += 1,
-            // Without a config, an agent in no repository belongs to the
-            // single shared room, so it is a member like any other.
-            None if matches!(grouping, Grouping::Inactive) => {
-                entry_for(&mut found, None).agents += 1
-            }
-            // Under a config the same agent is enrolled nowhere, and the
-            // ungrouped room receives nothing. Counting it would conjure a
-            // room out of one stray cwd whose only member can never be
-            // reached in it.
-            None => {}
-        }
-    }
+    let union = match memberships(grouping, agents, orgs) {
+        Some(m) => m,
+        None => return Vec::new(),
+    };
+    let mut found: BTreeMap<Option<String>, Room> = union
+        .into_iter()
+        // Without a config, an agent in no repository belongs to the single
+        // shared room, so it is a member like any other. Under a config the
+        // same agent is enrolled nowhere and the ungrouped room receives
+        // nothing, so the whole entry goes rather than just its count:
+        // keeping it at zero would still conjure a room out of one stray cwd
+        // whose only member can never be reached in it.
+        .filter(|(name, _)| name.is_some() || matches!(grouping, Grouping::Inactive))
+        .map(|(name, m)| {
+            let room = Room {
+                name: name.clone(),
+                agents: m.agents.len(),
+                configured: m.configured,
+                history: false,
+            };
+            (name, room)
+        })
+        .collect();
 
     if let Ok(entries) = std::fs::read_dir(session_dir) {
         for e in entries.flatten() {

--- a/src/groups.rs
+++ b/src/groups.rs
@@ -343,12 +343,26 @@ pub struct Membership<'a> {
 /// and the two callers want it read differently, so the split stays with
 /// them.
 ///
+/// That makes the `None` key a real entry every caller must decide about,
+/// where `rooms` used to simply never construct one under an active config.
+/// Dropping it is now the caller's job, not this function's: `rooms` filters
+/// the entry out, the `groups` listing prints it as a diagnostic, and a third
+/// caller that forgets would offer a room whose members can never be reached
+/// in it.
+///
 /// `None` for the whole map under `Broken`, and the two callers lean on that
 /// differently. `rooms` has no other refusal: it returns on this `None`, and
 /// deleting the guard would carry it past the config into the disk sweep,
 /// which never reads the config and would list every company's room. The
 /// `groups` listing refuses `Broken` above with its own message, so the arm
 /// is unreachable from there and is belt and braces behind that early-out.
+///
+/// The two therefore differ on purpose rather than by accident: `rooms` must
+/// return, because falling through reaches a disk sweep that never reads the
+/// config and would list every company's room, while the listing's default
+/// only ever produces an empty section under a message that already said the
+/// config is unreadable. `rooms` fails open where the listing fails closed,
+/// which is why one gets a hard return and the other tolerates a default.
 pub fn memberships<'a>(
     grouping: &Grouping,
     agents: &'a [crate::herd::AgentInfo],


### PR DESCRIPTION
Refs #38

`groups::rooms` and `cli::cmd_groups` each computed the config ∪ live-agents union. `groups::memberships` is now the one derivation; `rooms` folds its session-directory sweep onto it, and the `groups` listing reads its members and its `configured` flag from it.

## Contradiction with the issue, reported rather than absorbed

The issue offers "have `cmd_groups` derive its listing from `groups::rooms`" first. That direction cannot satisfy the byte-identical constraint, and the two outputs on the real config prove it:

```
$ scuttlebutt rooms          $ scuttlebutt groups
andybarilla  0  history      (absent)
```

`rooms` carries a third source — history on disk — that `groups` must not list, and `rooms` drops the ungrouped-under-`Active` section that `groups` prints as a diagnostic. Each direction breaks the other's output. Took the issue's sanctioned second option, extracting the union both call.

## Two commits, deliberately

The real config exercises only the configured path: no org-derived group, no ungrouped agents, no herd failure. Those are exactly where the new map gains keys and where the `None` bucket diverges between callers, so the byte-identical gate is weakest where the refactor is riskiest.

Commit 1 is a pure move — `render_groups` returns the listing as text — with four golden tests capturing today's output for the shapes `cmd_groups` cannot reach. Commit 2 is the collapse, with those tests unchanged.

## Where `Broken` is refused now

`rooms` lost its own early-out: it refuses `Broken` by returning on `memberships`' `None`. Deleting that guard does not produce an empty listing — it carries `rooms` past the config into the disk sweep, which never reads the config and would list every company's room. `groups::tests::a_broken_config_lists_no_room_at_all` is what holds it. The `groups` listing keeps its own early-out with its own message, so the same arm is unreachable from there; the doc says which caller is which.

## Verified

- `scuttlebutt groups` byte-identical against a baseline binary built from `ab257a9`, run interleaved so a status changing between runs shows as an unstable baseline rather than a false pass. `scuttlebutt rooms` identical too.
- 350 tests pass, CI green on c836995. Four mutations, each red in the expected place: dropping the `configured` skip in the second pass (2 red), keeping the ungrouped entry in `rooms` under a config (1 red), never marking `configured` (7 red), deleting `memberships`' `Broken` guard (1 red).

## What is left

#53 filed: `daemon::partition` is a third copy of the same agent-bucketing rule, in `daemon.rs` — out of this issue's scope and assigned elsewhere. #38 stays open until the lead reviews.