### PR TITLE
Refuse a clear verdict from a box the capture tore

### DIFF
--- a/src/herd.rs
+++ b/src/herd.rs
@@ -236,6 +236,11 @@ struct Regions {
 /// of — see `gutter_bounded`. A rule-bounded box is always whole: it is
 /// delimited by two matching rules rather than walked to, so a repaint that
 /// damages an edge costs the identification rather than a row.
+///
+/// It is carried per composer because that is where it is decided, but the
+/// verdict it feeds is pane-global: one composer read as partial stops the
+/// whole pane calling anything clear. Since `rule_bounded` never sets it
+/// false, a pane holding one gutter box behaves the same either way.
 struct Composer {
     rows: Vec<Row>,
     /// Whether the pane showed the whole box. Only a whole one may say a
@@ -511,20 +516,36 @@ fn bare_row(row: &str) -> String {
 /// blanks and the model footer, which reads as a cleared composer.
 ///
 /// `whole` is what stands between that and a dropped batch. The walk stops
-/// on the first row without a gutter, so that row says whether it stopped
-/// where the box ends or where the capture tore: every gutter box in every
-/// capture is drawn below a blank separator row, and a torn row is never
-/// blank, because it carries the text whose gutter it lost. Measured on all
-/// seven gutter-bounded fixtures and all four gutter-bounded live panes at
-/// the time of #51 — eleven of eleven, and none of those twenty-two
-/// verdicts changed by requiring it.
+/// on the first row without a gutter, and `whole` asks whether that is where
+/// the box ends: every gutter box in every capture is drawn below a blank
+/// separator, and above that separator is transcript. So the box is whole
+/// only if the row the walk stopped on is blank *and* the row above that
+/// carries no gutter. Measured on all seven gutter-bounded fixtures and all
+/// four gutter-bounded live panes at the time of #51 — eleven of eleven, and
+/// none of those twenty-two verdicts changed by requiring it.
 ///
-/// A box starting at the first line of the capture is not whole either, for
-/// the same reason and on weaker evidence: there is no row above to read,
-/// so nothing says whether one was torn or the box simply begins there. No
-/// capture is in that state, so unlike the rest of this its cost is
-/// unmeasured rather than measured at zero. It resolves the way everything
-/// unknown here resolves, toward a repeat rather than a drop.
+/// Both halves are needed, and the reason the second one is here is worth
+/// keeping. The first form of this rule was the blank row alone, justified
+/// by "a torn row is never blank, because it carries the text whose gutter
+/// it lost". That is false: a box's own blank rows carry nothing, so tearing
+/// one leaves a genuinely blank row and the tear reads as the separator. It
+/// is unreachable on the fixtures as captured, and only by accident — every
+/// box is four or five rows with at most one clear-voting row below its
+/// blank, so `bottom - top < 2` or #49 catches that tear first. One extra
+/// row below the blank makes it reachable. The row above the separator is
+/// what tells the two apart: under a torn blank sits the rest of the box,
+/// which still has its gutters.
+///
+/// A box with fewer than two rows above it is not whole either, and that
+/// half is a decision rather than a measurement: there is nothing to read,
+/// so nothing says whether a row was torn or the capture simply starts
+/// there. It costs a pane whose visible window is barely taller than its
+/// composer. Measured: `opencode-hint` clipped to begin at its box top, or
+/// one line above it, answers `None` — and a clear composer that answers
+/// `None` never confirms, so such a pane is #47's permanent re-prompter.
+/// Two rows of transcript are enough to clear it, and every capture we hold
+/// has far more. It resolves the way everything unknown here resolves,
+/// toward a repeat rather than a drop.
 fn gutter_bounded(lines: &[&str]) -> Vec<Composer> {
     let gutter = |l: &&str| l.trim_start().starts_with(|c| GUTTERS.contains(&c));
     let mut boxes = Vec::new();
@@ -547,15 +568,19 @@ fn gutter_bounded(lines: &[&str]) -> Vec<Composer> {
                     bare: bare_row(l),
                 })
                 .collect(),
-            // The walk stops at the first row without a gutter, so what
-            // stopped it says whether the box is all here. A blank row is
-            // the separator every capture draws above this box. Anything
-            // else is a row that had a gutter when it was drawn and lost it
-            // in the capture, and the box then starts below our text
-            // instead of above it — #51(a).
-            whole: top
-                .checked_sub(1)
-                .is_some_and(|a| lines[a].trim().is_empty()),
+            // The shape every capture draws above this box: transcript,
+            // then a blank separator. A row that had a gutter and lost it
+            // in the capture breaks one of the two — it is not blank if it
+            // carried text, and if it carried nothing then the row above it
+            // is still the box, still gutter-drawn. Either way the box
+            // starts below our text instead of above it — #51(a).
+            whole: {
+                let blank = top
+                    .checked_sub(1)
+                    .is_some_and(|a| lines[a].trim().is_empty());
+                let above_clear = top.checked_sub(2).is_some_and(|a| !gutter(&lines[a]));
+                blank && above_clear
+            },
         });
     }
     boxes
@@ -657,9 +682,10 @@ fn composer_holds(pane: &str, sent: &str) -> Option<bool> {
     // while our text sits two lines up, outside the box the walk found.
     // Whether it says so is not something the remaining rows can answer.
     //
-    // Every composer, rather than the one that voted, because the vote
-    // below is already collective — one truncated box means the pane's
-    // clear verdict rests on rows some of which we may not have seen.
+    // Pane-global, not per region: any partial composer stops every
+    // composer in the pane voting, because the vote below is collective
+    // anyway — `all` over every row of every one of them. One box we may
+    // not have seen the whole of is enough to make that verdict unsound.
     if composers.iter().any(|c| !c.whole) {
         return None;
     }
@@ -1677,6 +1703,70 @@ mod tests {
     }
 
     #[test]
+    fn a_torn_blank_row_does_not_leave_the_box_reading_as_whole() {
+        // The hole in this rule's first form, which said a torn row is
+        // never blank because it carries the text whose gutter it lost.
+        // False: a box's own blank rows carry nothing, so tearing one
+        // leaves a genuinely blank row and the tear reads as the separator.
+        //
+        // Unreachable on the fixtures as captured, and only by accident:
+        // every box is four or five rows with at most one clear-voting row
+        // below its blank, so `bottom - top < 2` or #49 catches the same
+        // tear first. One extra row below the blank makes it reachable, so
+        // the guard is a property of today's captures unless the row above
+        // the separator is checked too.
+        let lines: Vec<&str> = OC_WRAPPED.lines().collect();
+        let bottom = lines
+            .iter()
+            .rposition(|l| is_rule(l))
+            .expect("fixture lost its box");
+        // A two-row footer, which is all it takes.
+        let mut grown: Vec<String> = lines.iter().map(|l| l.to_string()).collect();
+        grown.insert(bottom, lines[bottom - 1].to_string());
+        assert_eq!(
+            composer_holds(&grown.join("\n"), OC_SENT),
+            Some(true),
+            "the grown pane should still hold our text before anything is torn"
+        );
+        let blank = grown
+            .iter()
+            .rposition(|l| {
+                bare_row(l).is_empty() && l.trim_start().starts_with(|c| GUTTERS.contains(&c))
+            })
+            .expect("no blank row inside the box");
+        grown[blank] = grown[blank].replacen('\u{2503}', " ", 1);
+        assert_ne!(
+            composer_holds(&grown.join("\n"), OC_SENT),
+            Some(false),
+            "a tear on the box's own blank row reported an unsent batch as submitted"
+        );
+    }
+
+    #[test]
+    fn a_box_with_no_separator_above_it_is_not_whole_either() {
+        // Pins the blank half of the rule on its own, and pins a decision
+        // rather than an observation: every capture draws the separator, so
+        // a box sitting straight under transcript is a shape none of them
+        // has. The row above the box is then not one this can read as an
+        // edge, and an unreadable edge resolves toward a repeat.
+        //
+        // Two transcript rows above the box, so the row two above it exists
+        // and carries no gutter: the other half of the rule is satisfied
+        // and only this half can answer.
+        let pane = format!(
+            "  a line of transcript\n  another line\n  \u{2503}\n  \u{2503}\n  \u{2503}  Build \u{b7} GPT-5.6 Sol OpenAI\n{}\n  status",
+            "\u{2500}".repeat(60)
+        );
+        assert_eq!(composer_holds(&pane, RULE), None);
+        // The same box with the separator restored confirms, so it is the
+        // missing separator answering here and not the rows or the footer.
+        assert_eq!(
+            composer_holds(&pane.replacen("  another line", "", 1), RULE),
+            Some(false)
+        );
+    }
+
+    #[test]
     fn a_gutter_box_is_only_whole_below_a_blank_row() {
         // What the rule above rests on, stated so a capture can refute it:
         // every real gutter box is preceded by a blank row, and a row that
@@ -1694,9 +1784,20 @@ mod tests {
             ("opencode-wrapped-cwd", OC_WRAPPED_CWD),
         ] {
             let lines: Vec<&str> = pane.lines().collect();
-            assert!(
-                !gutter_bounded(&lines).is_empty(),
-                "{name}: fixture lost its gutter box"
+            let boxes = gutter_bounded(&lines);
+            assert!(!boxes.is_empty(), "{name}: fixture lost its gutter box");
+            // `top_of_a_box` repeats `gutter_bounded`'s walk, so it can
+            // drift out of step with it silently. Tie the two together
+            // here: the rows between the helper's top and the closing rule
+            // have to be the rows the real walk returned.
+            let bottom = lines
+                .iter()
+                .rposition(|l| is_rule(l))
+                .expect("no rule to close a box");
+            assert_eq!(
+                bottom - top_of_a_box(&lines),
+                boxes.last().expect("checked non-empty").rows.len(),
+                "{name}: the test helper and gutter_bounded disagree on the box"
             );
             assert!(
                 gutter_bounded(&lines).iter().all(|c| c.whole),
@@ -1753,10 +1854,13 @@ mod tests {
             "\u{2500}".repeat(60)
         );
         assert_eq!(composer_holds(&pane, RULE), None);
-        // The same box below a blank row is the shape every capture has,
-        // and it confirms — so the blank row is doing the work here, not
-        // the footer or the box's contents.
-        assert_eq!(composer_holds(&format!("\n{pane}"), RULE), Some(false));
+        // The same box below the transcript-then-blank every capture draws
+        // above it confirms — so it is what sits above the box doing the
+        // work here, not the footer or the box's contents.
+        assert_eq!(
+            composer_holds(&format!("  a line of transcript\n\n{pane}"), RULE),
+            Some(false)
+        );
     }
 
     #[test]
@@ -1808,11 +1912,13 @@ mod tests {
     }
 
     fn gutter_box(rows: &[String]) -> String {
-        // The blank separator every captured gutter box is drawn below. It
-        // is what makes the box read as whole, so that the rows are what
-        // decides these tests rather than #51's truncation veto short-
-        // circuiting them.
-        let mut lines = vec![String::new()];
+        // The two rows every captured gutter box is drawn below: transcript,
+        // then the blank separator. Both are what make the box read as
+        // whole, so that these tests are decided by their own rows rather
+        // than by #51's truncation veto short-circuiting them. A pane that
+        // begins at its box, which is what this built before, is a shape no
+        // capture has.
+        let mut lines = vec!["  a line of transcript".to_string(), String::new()];
         lines.extend(rows.to_vec());
         lines.push("\u{2500}".repeat(BOX_WIDTH));
         lines.push("  status".into());

--- a/src/herd.rs
+++ b/src/herd.rs
@@ -226,8 +226,22 @@ fn is_rule(line: &str) -> bool {
 /// drop, and every layout this has been wrong about so far was one nobody
 /// had captured either.
 struct Regions {
-    composers: Vec<Vec<Row>>,
+    composers: Vec<Composer>,
     others: Vec<Vec<Row>>,
+}
+
+/// One identified composer, and whether the pane showed us all of it.
+///
+/// `whole` is false for a gutter-bounded box the walk did not reach the top
+/// of — see `gutter_bounded`. A rule-bounded box is always whole: it is
+/// delimited by two matching rules rather than walked to, so a repaint that
+/// damages an edge costs the identification rather than a row.
+struct Composer {
+    rows: Vec<Row>,
+    /// Whether the pane showed the whole box. Only a whole one may say a
+    /// composer is clear; a partial one can still say our text is on it,
+    /// since what it does hold is what it holds either way.
+    whole: bool,
 }
 
 /// One row of an identified region, in the two forms the verdict needs.
@@ -353,7 +367,10 @@ fn rule_bounded(lines: &[&str]) -> Regions {
     };
     for (i, region) in boxed.iter().enumerate() {
         match region {
-            Some((true, lines)) => regions.composers.push(lines.clone()),
+            Some((true, lines)) => regions.composers.push(Composer {
+                rows: lines.clone(),
+                whole: true,
+            }),
             Some((false, lines)) if composer_at(i + 1) || (i > 0 && composer_at(i - 1)) => {
                 regions.others.push(lines.clone())
             }
@@ -484,7 +501,31 @@ fn bare_row(row: &str) -> String {
 /// composer is another box closed by a rule, and returning only the lowest
 /// would replace the composer with the overlay and report the batch
 /// submitted from under it.
-fn gutter_bounded(lines: &[&str]) -> Vec<Vec<Row>> {
+///
+/// Walking up has a failure mode a rule-bounded box does not, and it is
+/// #51(a): a capture taken mid-repaint can lose the gutter character off a
+/// row, the walk stops there, and the box it returns starts *below* our
+/// text. It does not merely lose the torn row — it loses every row above
+/// it. On `opencode-wrapped` that costs the first half of a wrapped batch,
+/// eleven of our words, so a long batch is no protection. What is left is
+/// blanks and the model footer, which reads as a cleared composer.
+///
+/// `whole` is what stands between that and a dropped batch. The walk stops
+/// on the first row without a gutter, so that row says whether it stopped
+/// where the box ends or where the capture tore: every gutter box in every
+/// capture is drawn below a blank separator row, and a torn row is never
+/// blank, because it carries the text whose gutter it lost. Measured on all
+/// seven gutter-bounded fixtures and all four gutter-bounded live panes at
+/// the time of #51 — eleven of eleven, and none of those twenty-two
+/// verdicts changed by requiring it.
+///
+/// A box starting at the first line of the capture is not whole either, for
+/// the same reason and on weaker evidence: there is no row above to read,
+/// so nothing says whether one was torn or the box simply begins there. No
+/// capture is in that state, so unlike the rest of this its cost is
+/// unmeasured rather than measured at zero. It resolves the way everything
+/// unknown here resolves, toward a repeat rather than a drop.
+fn gutter_bounded(lines: &[&str]) -> Vec<Composer> {
     let gutter = |l: &&str| l.trim_start().starts_with(|c| GUTTERS.contains(&c));
     let mut boxes = Vec::new();
     for (bottom, _) in lines.iter().enumerate().filter(|(_, l)| is_rule(l)) {
@@ -498,15 +539,24 @@ fn gutter_bounded(lines: &[&str]) -> Vec<Vec<Row>> {
             continue;
         }
         let span = box_span(lines[bottom]);
-        boxes.push(
-            lines[top..bottom]
+        boxes.push(Composer {
+            rows: lines[top..bottom]
                 .iter()
                 .map(|l| Row {
                     text: boxed_row(l, span),
                     bare: bare_row(l),
                 })
                 .collect(),
-        );
+            // The walk stops at the first row without a gutter, so what
+            // stopped it says whether the box is all here. A blank row is
+            // the separator every capture draws above this box. Anything
+            // else is a row that had a gutter when it was drawn and lost it
+            // in the capture, and the box then starts below our text
+            // instead of above it — #51(a).
+            whole: top
+                .checked_sub(1)
+                .is_some_and(|a| lines[a].trim().is_empty()),
+        });
     }
     boxes
 }
@@ -535,13 +585,19 @@ fn is_our_text(content: &str, sent: &str) -> bool {
 ///
 /// `Some(false)` — submitted — is the only answer that advances a cursor and
 /// so the only one that can lose a batch, and it is reachable on exactly one
-/// path: at least one composer was identified, and every one of its rows says
-/// so on evidence no measurement produced. A row says so by being empty
+/// path: at least one composer was identified, every one of them was read
+/// whole, and every one of their rows says so on evidence no measurement
+/// produced. A row says so by being empty
 /// before any clip, span or width calculation ran, or by carrying enough
 /// words to be recognized as text that is not ours while the clip took
 /// nothing off it. That is #47: a clip, a span or a width calculation cannot
 /// manufacture the evidence of a clear composer, because neither thing a row
 /// may vote on is anything they had a hand in.
+///
+/// Reading the box whole is #51, and it is a condition of its own rather
+/// than a third thing a row may vote on, because no row can carry it: the
+/// rows a tear costs are the ones that are missing. See `gutter_bounded`.
+///
 /// Everything else is `None`, including cases that look like nothing at all:
 /// no composer identified in either layout, a marker we do not know, a
 /// queue hint standing in for the composer's contents, or content too short
@@ -573,7 +629,7 @@ fn composer_holds(pane: &str, sent: &str) -> Option<bool> {
         return None;
     }
     let sent = normalize(sent);
-    let joined = |c: &Vec<Row>| {
+    let joined = |c: &[Row]| {
         c.iter()
             .map(|r| r.text.as_str())
             .collect::<Vec<_>>()
@@ -581,7 +637,8 @@ fn composer_holds(pane: &str, sent: &str) -> Option<bool> {
     };
     if composers
         .iter()
-        .chain(&others)
+        .map(|c| c.rows.as_slice())
+        .chain(others.iter().map(Vec::as_slice))
         .any(|c| is_our_text(&joined(c), &sent))
     {
         return Some(true);
@@ -594,9 +651,21 @@ fn composer_holds(pane: &str, sent: &str) -> Option<bool> {
     if !others.is_empty() {
         return None;
     }
+    // A box read whole is the precondition for reading anything off its
+    // rows: a gutter that the capture lost truncates the box at that row
+    // and takes every row above it, so what is left can be entirely blank
+    // while our text sits two lines up, outside the box the walk found.
+    // Whether it says so is not something the remaining rows can answer.
+    //
+    // Every composer, rather than the one that voted, because the vote
+    // below is already collective — one truncated box means the pane's
+    // clear verdict rests on rows some of which we may not have seen.
+    if composers.iter().any(|c| !c.whole) {
+        return None;
+    }
     // Only a region something identified as a composer can say a composer
     // is clear. `others` has already had its say above.
-    let rows = || composers.iter().flatten();
+    let rows = || composers.iter().flat_map(|c| &c.rows);
     // A composer showing a queue hint is showing neither our text nor a
     // clear box: the queue it names may hold our batch or may not, and
     // nothing in the pane says which.
@@ -1426,7 +1495,10 @@ mod tests {
         // entirely and leave rows that are all empty, which reads as clear.
         let run = "\u{2500}".repeat(RULE_RUN);
         let bottom = format!("{run} \u{6982}\u{8981} {run}");
-        let pane = format!("  \u{2503}\n  \u{2503}  Reply only\n  \u{2503}\n{bottom}\n  status");
+        // Drawn below the blank separator every captured gutter box has,
+        // so that the clip is what decides this and not #51's truncation
+        // veto, which answers a box with nothing above it first.
+        let pane = format!("\n  \u{2503}\n  \u{2503}  Reply only\n  \u{2503}\n{bottom}\n  status");
         assert_eq!(box_span(&bottom), (0, display_width(&bottom)));
         assert_ne!(composer_holds(&pane, RULE), Some(false));
     }
@@ -1575,14 +1647,149 @@ mod tests {
     }
 
     #[test]
+    fn a_torn_gutter_row_stops_the_box_it_truncated_from_confirming() {
+        // #51(a), on the two real captures that reach `Some(false)` with a
+        // batch unsent. Losing one gutter character does not merely drop
+        // that row: `gutter_bounded` walks up from the closing rule and
+        // stops at the first row without a gutter, so the tear truncates
+        // the box and takes every row above it. Tearing the second half of
+        // a wrap in `opencode-wrapped` costs the first half too, which is
+        // eleven of our words — batch length is no protection.
+        for (name, pane, torn) in [
+            // the tail of a wrapped batch; the row above it holds the rest
+            ("opencode-wrapped", OC_WRAPPED, "or repeat. Under 80 words"),
+            // a two-word prompt, the whole of what was typed
+            ("opencode-short", OC_SHORT, "Reply only"),
+        ] {
+            let lines: Vec<String> = pane
+                .lines()
+                .map(|l| match l.contains(torn) {
+                    true => l.replacen('\u{2503}', " ", 1),
+                    false => l.to_string(),
+                })
+                .collect();
+            assert_ne!(
+                composer_holds(&lines.join("\n"), OC_SENT),
+                Some(false),
+                "{name}: a truncated box reported an unsent batch as submitted"
+            );
+        }
+    }
+
+    #[test]
+    fn a_gutter_box_is_only_whole_below_a_blank_row() {
+        // What the rule above rests on, stated so a capture can refute it:
+        // every real gutter box is preceded by a blank row, and a row that
+        // lost its gutter is not blank, because it carries the text whose
+        // gutter it lost. Measured on all seven gutter-bounded fixtures and
+        // all four gutter-bounded live panes at the time of #51 — eleven of
+        // eleven, no exceptions.
+        for (name, pane) in [
+            ("opencode-empty", OC_EMPTY),
+            ("opencode-hint", OC_HINT),
+            ("opencode-holds-batch", OC_HOLDS),
+            ("opencode-live-room", OC_LIVE),
+            ("opencode-short", OC_SHORT),
+            ("opencode-wrapped", OC_WRAPPED),
+            ("opencode-wrapped-cwd", OC_WRAPPED_CWD),
+        ] {
+            let lines: Vec<&str> = pane.lines().collect();
+            assert!(
+                !gutter_bounded(&lines).is_empty(),
+                "{name}: fixture lost its gutter box"
+            );
+            assert!(
+                gutter_bounded(&lines).iter().all(|c| c.whole),
+                "{name}: a real capture reads as truncated"
+            );
+            // The other half of the premise, and what gives this test teeth:
+            // tearing the gutter off the row above a box has to make that
+            // box read as truncated. Without it this passes under any rule
+            // that calls every box whole.
+            let torn: Vec<String> = lines
+                .iter()
+                .enumerate()
+                .map(|(i, l)| match i + 1 == top_of_a_box(&lines) {
+                    true => format!("{l} someone else was typing"),
+                    false => l.to_string(),
+                })
+                .collect();
+            let torn: Vec<&str> = torn.iter().map(String::as_str).collect();
+            assert!(
+                gutter_bounded(&torn).iter().any(|c| !c.whole),
+                "{name}: a non-blank row above a box left it reading as whole"
+            );
+        }
+    }
+
+    /// The first row of the lowest gutter box in `lines`, so a test can put
+    /// something on the row above it.
+    fn top_of_a_box(lines: &[&str]) -> usize {
+        let bottom = lines
+            .iter()
+            .rposition(|l| is_rule(l))
+            .expect("no rule to close a box");
+        let mut top = bottom;
+        while top > 0
+            && lines[top - 1]
+                .trim_start()
+                .starts_with(|c| GUTTERS.contains(&c))
+        {
+            top -= 1;
+        }
+        top
+    }
+
+    #[test]
+    fn a_gutter_box_at_the_top_of_a_capture_is_not_read_as_whole() {
+        // The half of the rule that is not measured: with no row above the
+        // box there is nothing to say whether one was torn off or the
+        // capture simply starts there. No fixture and no live pane is in
+        // this state, so this pins a decision rather than an observation —
+        // it resolves toward a repeat, which is what every other unknown
+        // here resolves toward.
+        let pane = format!(
+            "  \u{2503}\n  \u{2503}\n  \u{2503}  Build \u{b7} GPT-5.6 Sol OpenAI\n{}\n  status",
+            "\u{2500}".repeat(60)
+        );
+        assert_eq!(composer_holds(&pane, RULE), None);
+        // The same box below a blank row is the shape every capture has,
+        // and it confirms — so the blank row is doing the work here, not
+        // the footer or the box's contents.
+        assert_eq!(composer_holds(&format!("\n{pane}"), RULE), Some(false));
+    }
+
+    #[test]
+    fn a_truncated_box_can_still_say_our_text_is_on_it() {
+        // The veto is one-way. A box the walk did not read whole may not
+        // call a composer clear, but what it does hold it still holds:
+        // reading it as `None` when our text is right there would turn a
+        // confirmed hold into an unconfirmed one and widen the backoff for
+        // nothing.
+        let lines: Vec<String> = OC_WRAPPED
+            .lines()
+            .map(|l| match l.contains("Reply only if you have") {
+                // tear the FIRST wrap row: the walk still reaches the
+                // second, which carries a three-word window of ours
+                true => l.replacen('\u{2503}', " ", 1),
+                false => l.to_string(),
+            })
+            .collect();
+        assert_eq!(composer_holds(&lines.join("\n"), OC_SENT), Some(true));
+    }
+
+    #[test]
     fn a_gutter_box_without_a_footer_still_holds_what_is_in_it() {
         // The model footer used to be popped off the last row on its shape
         // alone — non-empty, blank row above it. A composer holding two
         // words has exactly that shape, and popping it left rows that were
         // all empty, which is a cleared composer. Per-row classification
         // does the work the pop was there for, so there is nothing to pop.
+        // Below a blank separator, as every capture draws it, so that the
+        // per-row classification is what answers here rather than #51's
+        // truncation veto.
         let pane = format!(
-            "  \u{2503}\n  \u{2503}\n  \u{2503}  Reply only\n{}\n  status",
+            "\n  \u{2503}\n  \u{2503}\n  \u{2503}  Reply only\n{}\n  status",
             "\u{2500}".repeat(60)
         );
         assert_eq!(composer_holds(&pane, RULE), None);
@@ -1601,7 +1808,12 @@ mod tests {
     }
 
     fn gutter_box(rows: &[String]) -> String {
-        let mut lines = rows.to_vec();
+        // The blank separator every captured gutter box is drawn below. It
+        // is what makes the box read as whole, so that the rows are what
+        // decides these tests rather than #51's truncation veto short-
+        // circuiting them.
+        let mut lines = vec![String::new()];
+        lines.extend(rows.to_vec());
         lines.push("\u{2500}".repeat(BOX_WIDTH));
         lines.push("  status".into());
         lines.join("\n")
@@ -1614,7 +1826,7 @@ mod tests {
         composer_regions(pane)
             .composers
             .iter()
-            .map(|c| c.iter().map(|r| r.text.clone()).collect())
+            .map(|c| c.rows.iter().map(|r| r.text.clone()).collect())
             .collect()
     }
 


### PR DESCRIPTION
Closes reproducer (a) from #51: a composer box the capture tore may no longer say it is clear. `herd.rs` only. The investigation this rests on is on the issue: https://github.com/andybarilla/herdr-scuttlebutt/issues/51#issuecomment-5431959724

## The mechanism, corrected

The issue says a torn repaint "excludes that row from the box entirely". It does more than that, and the difference is what makes this a drop rather than a curiosity.

`gutter_bounded` finds an OpenCode composer by walking up from its closing rule while rows carry a gutter. A capture taken mid-repaint can lose that character off a row, and the walk stops there — so the box it returns **starts below our text and loses every row above the tear**. What is left is blank rows and the model footer, and the footer honestly votes "not ours". That is `Some(false)`, which is the only verdict that advances a cursor.

Measured on real captures, tearing one gutter character:

| capture | what it held | tear | before | after |
|---|---|---|---|---|
| `opencode-short` | `Reply only` — two words | row 7 | `Some(false)` — **batch dropped** | `None` |
| `opencode-wrapped` | full batch, wrapped over rows 7–8 | row 8 | `Some(false)` — **batch dropped** | `None` |
| `opencode-wrapped` | same | row 7 | `Some(true)` | `Some(true)` |

Tearing row 8 of `opencode-wrapped` is the case worth reading: row 8 is only the tail of a wrap, and losing it costs row 7 as well — eleven of our words. A long batch is no protection, and this is why.

## The rule

A gutter box is read as **whole** only when the row the walk stopped on is blank **and the row above that carries no gutter.** Only a whole box may say a composer is clear; a partial one can still say our text is on it.

Every gutter box in every capture we hold is drawn below a blank separator, and above that separator is transcript — **7 gutter-bounded fixtures and 4 gutter-bounded live panes, 11 of 11, no exceptions.**

### Round two: the first form of this rule rested on a false premise

It was the blank row alone, justified by *"a torn row is never blank, because it carries the text whose gutter it lost"*. **That is false.** A box's own blank rows carry nothing — `opencode-wrapped` rows 6 and 9, `-short` 6 and 8, `-hint` 6 and 8, `-live-room` 53–55, `-wrapped-cwd` 53–54 — so tearing one leaves a genuinely blank row and the tear reads as the separator.

It was not reachable on the fixtures as captured, and the reason matters: every box is 4–5 rows with at most one clear-voting row below its blank, so `bottom - top < 2` or #49's clip-clean rule catches that tear first. **So the guard actually preventing that drop today was #49's, not this one**, and one extra row below the blank makes it reachable. Demonstrated in `a_torn_blank_row_does_not_leave_the_box_reading_as_whole`: `opencode-wrapped` with its own footer row duplicated, then the blank torn, gave `Some(false)` with our text still on the pane. Same shape as the four-cell sidebar margin recorded on #47 — a property of today's captures standing in for a property of the code.

The row above the separator tells the two apart: under a real separator sits transcript; under a torn blank sits the rest of the box, which still has its gutters. Both halves are now pinned separately (see the mutation table).

### The line-0 half, with its cost now measured

A box with fewer than two rows above it is not whole. Still a decision rather than a measurement — there is nothing to read, so nothing says whether a row was torn or the capture simply starts there — but the cost is no longer unquantified: **`opencode-hint` clipped to begin at its box top, or one line above it, answers `None`.** A clear composer that answers `None` never confirms, so a pane whose visible window is barely taller than its composer is #47's permanent re-prompter. Two rows of transcript clear it and every capture we hold has far more.

## Cost: zero, measured

Swept `composer_holds` over 13 checked-in fixtures and a live capture of all 9 named panes in `herdr agent list` (4 OpenCode, 5 Claude Code), each at two `sent` values — a synthetic batch and `OC_SENT`. **44 verdicts, byte-identical before and after.** No pane or fixture stops confirming, so the stall rate does not move on anything we hold. It rises only on panes actually caught mid-repaint, where a stall is the correct answer and #42 holds the batch.

## What is untouched

One-way by construction: the check sits after the `others` veto and before the row vote, and can only turn `Some(false)` into `None`. `#49`'s clip-clean rule, `same_box`, the adjacency filter, the `others` veto and the single `cell_width` metric are all unchanged. No version bump.

`Regions.composers` becomes `Vec<Composer>` so the flag is carried where it is decided. **Correcting my own earlier claim: the veto is pane-global, not per region.** `composers.iter().any(|c| !c.whole)` stops every composer in the pane voting, and since `rule_bounded` never sets it false, a pane holding one gutter box behaves identically either way. The vote it feeds is collective anyway — `all` over every row of every composer. Rule-bounded composers are always whole: they are delimited by two matching rules rather than walked to, so a repaint that damages an edge costs the identification, not a row.

## Mutation results

Every condition pinned by a distinct test, run against the shipped file:

| mutation | tests that fail |
|---|---|
| `blank` half deleted | `a_box_with_no_separator_above_it_is_not_whole_either`, `a_gutter_box_is_only_whole_below_a_blank_row` |
| `above_clear` half deleted | `a_torn_blank_row_does_not_leave_the_box_reading_as_whole` |
| `whole` always true | 5 tests |
| the veto deleted | 4 tests — **and none of #49's pins**, which is how I confirmed the adjusted tests are decided by their own reasons |
| #49's `bare == text` reverted | `a_row_the_clip_touched_cannot_say_a_composer_is_clear`, `an_echo_in_the_composers_own_gutter_is_not_a_composer` — #49 is still pinned non-vacuously |

Round one had both halves of the earlier condition unpinned; that is fixed.

## Two pre-existing tests changed, and why

`a_closing_rule_with_a_wide_label_measures_its_box_in_cells` and `a_gutter_box_without_a_footer_still_holds_what_is_in_it` both build a synthetic pane whose first line is a gutter row. Under this change the truncation veto would answer them before the clip or the per-row classification they exist to pin — they would still pass, for the wrong reason, and stop pinning #36 and #49. Each gained the blank separator line every real capture has. Verified: deleting this PR's veto leaves both passing.

## Verification

- `cargo test`: **352 passed, 0 failed** — 346 on `ab257a9`, plus the 6 tests added here. No test removed.
- `top_of_a_box`, the test helper that repeated `gutter_bounded`'s walk, is now tied to it: the test asserts the helper's box height equals the real walk's row count, so the two cannot drift apart silently.
- `cargo clippy --all-targets`: clean. `cargo fmt --check`: clean.
- Mutation-checked, each mutation caught by a distinct test: `whole` always true → 3 fail; the veto deleted → 2 fail; blankness ignored (`is_some()`) → 2 fail; line-0 treated as whole → 1 fail. Deleting the veto fails **only** the two tests written for it, which is how I confirmed the two adjusted tests went back to being decided by their own reasons.
- The 44-verdict sweep was run against this branch and against `origin/main` with the same harness and diffed; the harness is scratch and is not in this PR.

## Deliberately not done

**Reproducer (b) — furniture inside the box's own columns.** Not reproduced on any real capture, either layout: every gutter box ends at cell 257 while the sidebar starts at 261, so that furniture is always outside and always clipped; and every real Claude Code composer row is the bare marker or marker-plus-our-text, with nothing clipped at all. 0 of 13 fixtures, 0 of 9 live panes. Nothing proposed for a shape no capture has.

**The OpenCode idle hint**, which is the reachable member of this class and is not (b). `opencode-hint.txt` is a real capture whose composer shows `Ask anything...` and confirms today; since `herdr agent prompt` returns Ok on *accepted* rather than delivered, a paste that never lands leaves that hint showing and we confirm a delivery that did not happen. The only rule that reaches it is #47-literal, re-measured on today's fleet as making all 4 live OpenCode panes permanently unconfirmable. That trade is not mine to make. **#51 stays open for it.**

`Refs #51`