### PR TITLE
chore: release 0.2.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,7 +678,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scuttlebutt"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scuttlebutt"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ under `~/dev/printersrow`.
 ## Install
 
 ```sh
-herdr plugin install andybarilla/herdr-scuttlebutt --ref v0.2.4
+herdr plugin install andybarilla/herdr-scuttlebutt --ref v0.2.5
 ```
 
 The prebuilt binary is only used when the checkout is the commit that release

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,7 +1,7 @@
 # herdr-plugin.toml
 id = "andybarilla.scuttlebutt"
 name = "Scuttlebutt"
-version = "0.2.4"
+version = "0.2.5"
 min_herdr_version = "0.7.0"
 description = "Shared chat room for the agents in a herdr session"
 platforms = ["linux", "macos"]


### PR DESCRIPTION
Version bump only — `Cargo.toml`, `herdr-plugin.toml`, `Cargo.lock`, and the README install line — produced by `scripts/release.sh 0.2.5`. No behaviour change.

## What 0.2.5 ships

Fourteen issues closed since 0.2.4, all of them in the delivery path. The headline: **the room was dropping every batch after five failures, and nothing said so.**

- **#36** — confirmation found no composer in any layout this fleet actually runs, so every delivery was unconfirmable and the threshold force-skipped the batch. Six review rounds; ten real pane captures checked in as fixtures.
- **#39** — the threshold now stalls the agent and holds the batch instead of advancing the cursor over it, retrying on a widening backoff and naming the agent in `daemon-status`.
- **#43** — the absence purge no longer takes a held batch with the presence state it belongs to.
- **#47** — a measurement error can no longer be what says a composer is clear.
- **#51 (part one)** — a gutter box the capture tore may no longer say a composer is clear.
- **#58** — both routes out of a stall are gated on who is actually at the pane, closing a cross-delivery reachable in about four seconds.
- **#34, #35** — room enumeration and the Ctrl-K room switcher.
- **#38, #44 (part one), #45** — one union derivation for rooms and groups; the failure cap split into the two decisions it gated; a transient tail read no longer tears the chat pane down and loses every per-room draft.

Known and tracked, not shipped: #51's OpenCode idle-hint path, #57's gate staleness, #60's missing human exit for a stalled agent.

Refs #32