### PR TITLE
Derive delivery partitions from memberships

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -504,36 +504,38 @@ pub struct Announced {
 /// room used when grouping is inactive.
 type Buckets = Vec<(Option<String>, Vec<AgentInfo>)>;
 
-/// Splits agents into one bucket per group, plus the agents that belong to no
-/// group. Membership comes from `groups::resolve`, so an agent whose cwd no
-/// prefix claims still lands in its repository's org room. `Broken` yields no
-/// buckets at all: a config we cannot parse must never fall back to a room,
-/// because that would merge groups.
+/// Adapts `groups::memberships` into owned delivery buckets plus the borrowed
+/// agents that receive nothing. `ScopedHerd` needs owned `AgentInfo` values,
+/// while skipped-agent reporting only reads the original roster.
 ///
 /// The `None` bucket is a real room only while grouping is `Inactive` — that
 /// is v1's single room, and an agent outside any repo must not go dark just
 /// because someone else's repo created an org room. Under an `Active` config
-/// an unresolvable agent is skipped, as before.
+/// an unresolvable agent is skipped. Configured rooms with no live agents are
+/// omitted because there is no delivery pass to run for them. `Broken` yields
+/// no memberships, so every agent is skipped and no room can receive a post.
 pub fn partition<'a>(
     agents: &'a [AgentInfo],
     grouping: &Grouping,
     orgs: &mut crate::git_org::OrgCache,
 ) -> (Buckets, Vec<&'a AgentInfo>) {
-    if let Grouping::Broken(_) = grouping {
-        return (Vec::new(), agents.iter().collect());
-    }
-    let shared_room = matches!(grouping, Grouping::Inactive);
-    let mut buckets: std::collections::BTreeMap<Option<String>, Vec<AgentInfo>> =
-        std::collections::BTreeMap::new();
+    let memberships = match groups::memberships(grouping, agents, orgs) {
+        Some(memberships) => memberships,
+        None => return (Vec::new(), agents.iter().collect()),
+    };
+    let mut buckets = Vec::new();
     let mut skipped = Vec::new();
-    for a in agents {
-        match groups::resolve(Path::new(&a.cwd), grouping, orgs) {
-            Some(g) => buckets.entry(Some(g)).or_default().push(a.clone()),
-            None if shared_room => buckets.entry(None).or_default().push(a.clone()),
-            None => skipped.push(a),
+    for (group, membership) in memberships {
+        if membership.agents.is_empty() {
+            continue;
+        }
+        if group.is_none() && matches!(grouping, Grouping::Active(_)) {
+            skipped.extend(membership.agents);
+        } else {
+            buckets.push((group, membership.agents.into_iter().cloned().collect()));
         }
     }
-    (buckets.into_iter().collect(), skipped)
+    (buckets, skipped)
 }
 
 /// Presents one group's members to the unchanged `tick`, so `tick` needs no
@@ -5165,6 +5167,110 @@ mod tests {
             .collect();
         v.sort();
         v
+    }
+
+    fn membership_names(
+        memberships: Option<
+            std::collections::BTreeMap<Option<String>, crate::groups::Membership<'_>>,
+        >,
+    ) -> Option<Vec<(Option<String>, Vec<String>)>> {
+        memberships.map(|memberships| {
+            memberships
+                .into_iter()
+                .map(|(group, membership)| {
+                    (
+                        group,
+                        membership
+                            .agents
+                            .into_iter()
+                            .map(|agent| agent.name.clone())
+                            .collect(),
+                    )
+                })
+                .collect()
+        })
+    }
+
+    #[test]
+    fn partition_delivery_matches_memberships_in_every_grouping_state() {
+        let agents = vec![
+            agent_at("grouped", "/w/alare/api", "idle"),
+            agent_at("fallback", "/w/beta/web", "idle"),
+            agent_at("stray", "/tmp/scratch", "idle"),
+        ];
+
+        let inactive = crate::groups::Grouping::Inactive;
+        assert_eq!(
+            membership_names(crate::groups::memberships(
+                &inactive,
+                &agents,
+                &mut orgs(fake_org),
+            )),
+            Some(vec![
+                (None, vec!["stray".to_string()]),
+                (Some("alare".into()), vec!["grouped".into()]),
+                (Some("beta".into()), vec!["fallback".into()]),
+            ])
+        );
+        let (buckets, skipped) = partition(&agents, &inactive, &mut orgs(fake_org));
+        assert_eq!(
+            bucket_names(buckets),
+            vec![
+                (None, vec!["stray".to_string()]),
+                (Some("alare".into()), vec!["grouped".into()]),
+                (Some("beta".into()), vec!["fallback".into()]),
+            ]
+        );
+        assert!(skipped.is_empty());
+
+        let active = two_group_rules();
+        assert_eq!(
+            membership_names(crate::groups::memberships(
+                &active,
+                &agents,
+                &mut orgs(fake_org),
+            )),
+            Some(vec![
+                (None, vec!["stray".to_string()]),
+                (Some("acme".into()), vec![]),
+                (Some("alare".into()), vec!["grouped".into()]),
+                (Some("beta".into()), vec!["fallback".into()]),
+            ])
+        );
+        let (buckets, skipped) = partition(&agents, &active, &mut orgs(fake_org));
+        assert_eq!(
+            bucket_names(buckets),
+            vec![
+                (Some("alare".into()), vec!["grouped".into()]),
+                (Some("beta".into()), vec!["fallback".into()]),
+            ]
+        );
+        assert_eq!(
+            skipped
+                .into_iter()
+                .map(|agent| agent.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["stray"]
+        );
+
+        let broken = crate::groups::Grouping::Broken("bad".into());
+        assert_eq!(
+            membership_names(crate::groups::memberships(
+                &broken,
+                &agents,
+                &mut orgs(fake_org),
+            )),
+            None
+        );
+        let (buckets, skipped) = partition(&agents, &broken, &mut orgs(fake_org));
+        assert!(buckets.is_empty());
+        assert_eq!(
+            skipped
+                .into_iter()
+                .map(|agent| agent.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["grouped", "fallback", "stray"]
+        );
     }
 
     #[test]

--- a/src/groups.rs
+++ b/src/groups.rs
@@ -321,12 +321,11 @@ fn entry_for(found: &mut BTreeMap<Option<String>, Room>, name: Option<String>) -
 }
 
 /// One room's membership as the config and the live roster see it. These are
-/// the two sources `rooms` and the `groups` listing both derive from, and
-/// deriving them twice is what let the two commands disagree about which
-/// rooms exist. The session-directory sweep is `rooms`' third source and is
+/// the shared sources for room discovery, the `groups` listing, and daemon
+/// delivery. The session-directory sweep is `rooms`' third source and is
 /// deliberately not here: a room surviving only as history has no membership
-/// to hold, and sweeping the disk on the `groups` path would mean listing
-/// rooms the config never named.
+/// to hold, and sweeping the disk on the other paths would invent live
+/// membership from history.
 #[derive(Debug, Default)]
 pub struct Membership<'a> {
     /// Named by `groups.toml`.
@@ -340,29 +339,29 @@ pub struct Membership<'a> {
 /// with `None` for the ungrouped room. The `None` key holds agents that
 /// resolve nowhere under *any* grouping — that bucket means "receiving
 /// nothing" under an active config and "the single shared room" without one,
-/// and the two callers want it read differently, so the split stays with
-/// them.
+/// and callers need to read it differently, so the split stays with them.
 ///
 /// That makes the `None` key a real entry every caller must decide about,
 /// where `rooms` used to simply never construct one under an active config.
-/// Dropping it is now the caller's job, not this function's: `rooms` filters
-/// the entry out, the `groups` listing prints it as a diagnostic, and a third
-/// caller that forgets would offer a room whose members can never be reached
-/// in it.
+/// Dropping it is the caller's job, not this function's: `rooms` filters the
+/// entry out, the `groups` listing prints it as a diagnostic, and daemon
+/// partitioning turns its agents into the skipped list. Any other treatment
+/// would offer a room whose members can never be reached in it.
 ///
-/// `None` for the whole map under `Broken`, and the two callers lean on that
+/// `None` for the whole map under `Broken`, and callers lean on that
 /// differently. `rooms` has no other refusal: it returns on this `None`, and
 /// deleting the guard would carry it past the config into the disk sweep,
 /// which never reads the config and would list every company's room. The
 /// `groups` listing refuses `Broken` above with its own message, so the arm
 /// is unreachable from there and is belt and braces behind that early-out.
+/// Daemon partitioning converts it to no buckets with the whole roster
+/// skipped, preserving fail-closed delivery while retaining diagnostics.
 ///
-/// The two therefore differ on purpose rather than by accident: `rooms` must
-/// return, because falling through reaches a disk sweep that never reads the
-/// config and would list every company's room, while the listing's default
+/// `rooms` and the listing therefore use different guards on purpose: `rooms`
+/// must return, because falling through reaches a disk sweep that never reads
+/// the config and would list every company's room, while the listing's default
 /// only ever produces an empty section under a message that already said the
-/// config is unreadable. `rooms` fails open where the listing fails closed,
-/// which is why one gets a hard return and the other tolerates a default.
+/// config is unreadable. Both remain fail-closed for room membership.
 pub fn memberships<'a>(
     grouping: &Grouping,
     agents: &'a [crate::herd::AgentInfo],


### PR DESCRIPTION
Refs #53

- adapt the shared memberships union into owned daemon delivery buckets
- preserve skipped-agent and fail-closed behavior across all grouping states
- add a regression matrix covering inactive, active, and broken grouping

Verification:
- scripts/check-versions.sh
- cargo fmt --check
- cargo clippy --all-targets --locked -- -D warnings
- cargo test --locked