### PR TITLE
chore: release 0.2.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,7 +678,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scuttlebutt"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scuttlebutt"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ under `~/dev/printersrow`.
 ## Install
 
 ```sh
-herdr plugin install andybarilla/herdr-scuttlebutt --ref v0.2.5
+herdr plugin install andybarilla/herdr-scuttlebutt --ref v0.2.6
 ```
 
 The prebuilt binary is only used when the checkout is the commit that release

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,7 +1,7 @@
 # herdr-plugin.toml
 id = "andybarilla.scuttlebutt"
 name = "Scuttlebutt"
-version = "0.2.5"
+version = "0.2.6"
 min_herdr_version = "0.7.0"
 description = "Shared chat room for the agents in a herdr session"
 platforms = ["linux", "macos"]


### PR DESCRIPTION
## Summary
- bump package, plugin, lockfile, and install ref to 0.2.6

## Verification
- scripts/check-versions.sh
- cargo test --locked
- cargo fmt -- --check
- cargo clippy --all-targets --locked -- -D warnings

Refs #70

The issue remains open for the post-merge tag and release-asset verification, gated on review, green CI, and merge.